### PR TITLE
Support options from task and config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Changelog
 
 ## v0.14.1 (Unreleased)
+  * Enhancements
+    * Implicitly use `.sobelow-conf` if detected in the root directory rather than
+      require `--config` switch. The `--no-config` switch is still supported to
+      prevent any settings from being read in from the file if needed.
+
   * Bug fixes
     * Handled extra config options for app releases in mix.exs
+    * Properly handle the use of CLI switches and config file settings in the same run.
+      These would previously clobber each other in unapparent ways leading to
+      confusing behavior. CLI switch take precedence.
 
 ## v0.14.0
   * Removed

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ relative to the application root.
   line options. See [Configuration Files](#configuration-files) for more
   information.
 
-  * `--config` - Run Sobelow with configuration file. See [Configuration Files](#configuration-files)
+  * `--[no-]config` - Run Sobelow with or without configuration file. See [Configuration Files](#configuration-files)
   for more information.
 
   * `--mark-skip-all` - Mark all displayed findings as skippable.
@@ -170,10 +170,9 @@ when you first start out using this package - the generated configuration file
 will be populated with the default values for each option. (This helps in
 quickly incorporating this package into a pre-existing codebase.)
 
-Now if you want to run Sobelow with the saved configuration,
-you can run Sobelow with the `--config` flag.
-
-    $ mix sobelow --config
+The `.sobelow-conf` file is automatically used if detected. CLI switches will
+take precedence over options in the config file. You can also specify
+`--no-config` to prevent any config file settings being used if needed.
 
 ## False Positives
 Sobelow favors over-reporting versus under-reporting. As such,
@@ -226,7 +225,7 @@ defp aliases do
 end
 ```
 
-If you wish to use configuration files in an umbrella app, create a `.sobelow-conf` in each child application and use the `--config` flag.
+If you wish to use configuration files in an umbrella app, create a `.sobelow-conf` in each child application.
 
 ## Updates
 When scanning a project, Sobelow will occasionally check for

--- a/lib/mix/tasks/sobelow.ex
+++ b/lib/mix/tasks/sobelow.ex
@@ -30,7 +30,7 @@ defmodule Mix.Tasks.Sobelow do
   * `--quiet` - Return no output if there are no findings
   * `--compact` - Minimal, single-line findings
   * `--save-config` - Generates a configuration file based on command line options
-  * `--config` - Run Sobelow with configuration file
+  * `--[no-]config` - Run Sobelow with or without the configuration file.
   * `--version` - Output current version of Sobelow
 
   ## Ignoring modules


### PR DESCRIPTION
(Transferred from https://github.com/nccgroup/sobelow/pull/170)

Previously, if you attempted to mix options from the config file or via task switches, they would clobber each other producing mixed results. But it wasn't clear this behavior was not supported.

This changes to support reading from config file _and_ mix task switches merging the options together. The task switches take precedence.

It also defaults to using the config file if it is present, but leaves the switch so that `--no-config` could be used to explicitly ignore the config file instead