### PR TITLE
Update CI latest elixir version to 1.18

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -52,11 +52,11 @@ jobs:
         run: mix hex.audit
 
       - name: Check Formatting
-        if: ${{ matrix.elixir == '1.16.x' }} # we only care about formatting for latest version of Elixir
+        if: ${{ matrix.elixir == '1.18.x' }} # we only care about formatting for latest version of Elixir
         run: mix format --check-formatted
 
       - name: Compiles w/o Warnings
-        if: ${{ matrix.elixir == '1.16.x' }} # we only care about warnings for latest version of Elixir
+        if: ${{ matrix.elixir == '1.18.x' }} # we only care about warnings for latest version of Elixir
         run: mix compile --warnings-as-errors
 
       - name: Credo


### PR DESCRIPTION
This updates the latest Elixir version in CI to 1.18 so that the formatting and version specific checks are run against the most recent rather than past versions.