### PR TITLE
Fix Format & Warnings Check in CI

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -31,6 +31,8 @@ jobs:
             otp: 27
           - elixir: "1.18.x"
             otp: 27
+            # We only care about formatting and warnings for the latest version of Elixir
+            checkFormatAndWarnings: true
 
     steps:
       - name: Setup Elixir
@@ -52,11 +54,11 @@ jobs:
         run: mix hex.audit
 
       - name: Check Formatting
-        if: ${{ matrix.elixir == '1.16.x' }} # we only care about formatting for latest version of Elixir
+        if: ${{ matrix.checkFormatAndWarnings }}
         run: mix format --check-formatted
 
       - name: Compiles w/o Warnings
-        if: ${{ matrix.elixir == '1.16.x' }} # we only care about warnings for latest version of Elixir
+        if: ${{ matrix.checkFormatAndWarnings }}
         run: mix compile --warnings-as-errors
 
       - name: Credo


### PR DESCRIPTION
Hello 👋🏼 

The current CI workflows check formatting and compilation warnings on Elixir 1.16 despite adding 1.17 and 1.18 to the matrix. This PR changes the manner in which the "latest" version is determined. By hoisting the decision upwards, it will hopefully be easier / more natural to keep it up-to-date.

You can see the changes in action [here](https://github.com/aj-foster/sobelow/actions/runs/15359838921).

Cheers! ❤️ 