### PR TITLE
fix warning from zero arg functions from endpoint

### DIFF
--- a/lib/sobelow/parse.ex
+++ b/lib/sobelow/parse.ex
@@ -461,7 +461,7 @@ defmodule Sobelow.Parse do
     end
   end
 
-  defp create_fun_cap(fun, meta, idx) when is_number(idx) do
+  defp create_fun_cap(fun, meta, idx) when is_number(idx) and idx > 0 do
     opts = Enum.map(1..trunc(idx), fn i -> {:&, [], [i]} end)
     {fun, meta, opts}
   end


### PR DESCRIPTION
We get a warning when running sobelow on our project:

```elixir
warning: Range.new/2 and first..last default to a step of -1 when last < first. Use Range.new(first, last, -1) or first..last//-1, or pass 1 if that was your intention
  (sobelow 0.14.0) lib/sobelow/parse.ex:476: Sobelow.Parse.create_fun_cap/3
  (sobelow 0.14.0) lib/sobelow/parse.ex:445: Sobelow.Parse.get_funs_of_type/3
  (elixir 1.18.1) lib/macro.ex:618: Macro.do_traverse/4
  (stdlib 6.2) lists.erl:2343: :lists.mapfoldl_1/3
  (elixir 1.18.1) lib/macro.ex:624: Macro.do_traverse/4
```

I found out that is caused by passing a zero-arity function to a plug. This can be triggered in this repository by adding 

```elixir
  plug(Plug.None, none: &SobelowTestWeb.static_paths/0)
```

to `test/fixtures/cswh/soso_endpoint.ex` and then executing `mix test test/config/cswh_test.exs:60`:

```
❯ mix test test/config/cswh_test.exs:60
Compiling 41 files (.ex)
Generated sobelow app
Running ExUnit with seed: 295149, max_cases: 32
Excluding tags: [:test]
Including tags: [location: {"test/config/cswh_test.exs", 60}]

warning: Range.new/2 and first..last default to a step of -1 when last < first. Use Range.new(first, last, -1) or first..last//-1, or pass 1 if that was your intention
  (sobelow 0.14.0) lib/sobelow/parse.ex:465: Sobelow.Parse.create_fun_cap/3
  (sobelow 0.14.0) lib/sobelow/parse.ex:444: Sobelow.Parse.get_funs_of_type/3
  (elixir 1.18.1) lib/macro.ex:618: Macro.do_traverse/4
  (stdlib 6.2) lists.erl:2343: :lists.mapfoldl_1/3
  (elixir 1.18.1) lib/macro.ex:624: Macro.do_traverse/4
  (stdlib 6.2) lists.erl:2343: :lists.mapfoldl_1/3
  (stdlib 6.2) lists.erl:2344: :lists.mapfoldl_1/3
  (elixir 1.18.1) lib/macro.ex:604: Macro.do_traverse/4
  (stdlib 6.2) lists.erl:2343: :lists.mapfoldl_1/3
  (stdlib 6.2) lists.erl:2344: :lists.mapfoldl_1/3
  (elixir 1.18.1) lib/macro.ex:604: Macro.do_traverse/4
  (elixir 1.18.1) lib/macro.ex:619: Macro.do_traverse/4
  (stdlib 6.2) lists.erl:2343: :lists.mapfoldl_1/3
  (elixir 1.18.1) lib/macro.ex:624: Macro.do_traverse/4
  (stdlib 6.2) lists.erl:2343: :lists.mapfoldl_1/3
  (stdlib 6.2) lists.erl:2344: :lists.mapfoldl_1/3
  (elixir 1.18.1) lib/macro.ex:604: Macro.do_traverse/4

.
Finished in 0.00 seconds (0.00s async, 0.00s sync)
4 tests, 0 failures, 3 excluded
```

I did not add a test, as it is just a warning. Let me know if you need anything changed in this PR.