### PR TITLE
Sort elements in .sobelow-conf alphabetically

### DIFF
--- a/lib/sobelow.ex
+++ b/lib/sobelow.ex
@@ -239,16 +239,16 @@ defmodule Sobelow do
 
   def save_config(conf_file) do
     conf = [
-      verbose: get_env(:verbose),
-      private: get_env(:private),
-      skip: get_env(:skip),
-      router: get_env(:router),
       exit: get_env(:exit_on),
       format: get_env(:format),
-      out: get_env(:out),
-      threshold: get_env(:threshold),
-      ignore: get_env(:ignored),
       ignore_files: get_env(:ignored_files),
+      ignore: get_env(:ignored),
+      out: get_env(:out),
+      private: get_env(:private),
+      router: get_env(:router),
+      skip: get_env(:skip),
+      threshold: get_env(:threshold),
+      verbose: get_env(:verbose),
       version: get_env(:version)
     ]
 
@@ -260,7 +260,7 @@ defmodule Sobelow do
       end
 
     if yes? do
-      File.write!(conf_file, inspect(conf))
+      File.write!(conf_file, inspect(conf, limit: :infinity, printable_limit: :infinity))
       MixIO.info("Updated .sobelow-conf")
     end
   end


### PR DESCRIPTION
Additionally do not limit the amount of elements/length in it

This makes it easier to edit since as of now it is a long line.