### PR TITLE
Use `warn_if_outdated` option in Mix deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ To use Sobelow, you can add it to your application's dependencies.
 ```elixir
 def deps do
   [
-    {:sobelow, "~> 0.13", only: [:dev, :test], runtime: false}
+    {:sobelow, "~> 0.14", only: [:dev, :test], runtime: false, warn_if_outdated: true}
   ]
 end
 ```


### PR DESCRIPTION
This option has been recently introduced to Hex
https://hexdocs.pm/mix/main/Mix.Tasks.Deps.html#module-hex-options-hex
As as security tool it is highly recommended.