### PR TITLE
Fix skips

### DIFF
--- a/lib/sobelow.ex
+++ b/lib/sobelow.ex
@@ -209,14 +209,16 @@ defmodule Sobelow do
   end
 
   def log_finding(details, %Finding{} = finding) do
-    if loggable?(finding.fingerprint, finding.confidence) do
+    if loggable?(finding, finding.confidence) do
       Fingerprint.put(finding.fingerprint)
       FindingLog.add({details, finding}, finding.confidence)
     end
   end
 
-  def loggable?(fingerprint, severity) do
-    !(get_env(:skip) && Fingerprint.member?(fingerprint)) &&
+  def loggable?(%Finding{} = finding, severity) do
+    legacy_skip = finding.legacy_fingerprint && Fingerprint.member?(finding.legacy_fingerprint)
+    new_skip = finding.fingerprint && Fingerprint.member?(finding.fingerprint)
+    !(get_env(:skip) && (new_skip || legacy_skip)) &&
       meets_threshold?(severity)
   end
 
@@ -474,10 +476,41 @@ defmodule Sobelow do
       [] ->
         nil
 
-      fingerprints ->
+      new_fingerprints ->
+        # Get all findings from the log to match fingerprints to finding details
+        %{high: highs, medium: meds, low: lows} = FindingLog.log()
+        all_findings = highs ++ meds ++ lows
+
+        # Create a map of fingerprint -> finding for quick lookup
+        fingerprint_to_finding =
+          all_findings
+          |> Enum.map(fn {_details, finding} -> {finding.fingerprint, finding} end)
+          |> Map.new()
+
+        # Build skip entries in new format: type,filename,line,hash
+        skip_entries =
+          new_fingerprints
+          |> Enum.map(fn fingerprint ->
+            case Map.get(fingerprint_to_finding, fingerprint) do
+              %Finding{} = finding ->
+                # Get relative filename (remove project root)
+                filename =
+                  Utils.get_root()
+                  |> Utils.normalize_path()
+                  |> (&String.replace_prefix(finding.filename, &1, "")).()
+                  |> Utils.normalize_path()
+
+                "#{finding.type},#{filename}:#{finding.vuln_line_no},#{fingerprint}"
+              nil ->
+                # Fallback to old format if we can't find the finding
+                fingerprint
+            end
+          end)
+
+
         {:ok, iofile} = :file.open(cfile, [:append])
-        fingerprints = Enum.join(fingerprints, "\n")
-        :file.write(iofile, ["\n", fingerprints])
+        entries_str = Enum.join(skip_entries, "\n")
+        :file.write(iofile, ["\n", entries_str])
         :file.close(iofile)
     end
   end
@@ -493,8 +526,23 @@ defmodule Sobelow do
     end
   end
 
-  defp load_ignored_fingerprints({:ok, fingerprint}, iofile) do
-    to_string(fingerprint) |> String.trim() |> Fingerprint.put_ignore()
+  defp load_ignored_fingerprints({:ok, line}, iofile) do
+    line_str = to_string(line) |> String.trim()
+
+    # Parse line - could be old format (just hash) or new format (type,filename:line,hash)
+    fingerprint = case String.split(line_str, ",") do
+      [fingerprint] when fingerprint != "" ->
+        # Old format: just the fingerprint hash
+        fingerprint
+      [_type, _filename_line_no, fingerprint] when fingerprint != "" ->
+        # New format: type,filename,line,hash - extract just the hash
+        fingerprint
+      _ ->
+        # Invalid line, skip it
+        nil
+    end
+
+    if fingerprint, do: Fingerprint.put_ignore(fingerprint)
     :file.read_line(iofile) |> load_ignored_fingerprints(iofile)
   end
 

--- a/lib/sobelow.ex
+++ b/lib/sobelow.ex
@@ -487,7 +487,7 @@ defmodule Sobelow do
           |> Enum.map(fn {_details, finding} -> {finding.fingerprint, finding} end)
           |> Map.new()
 
-        # Build skip entries in new format: type,filename,line,hash
+        # Build skip entries in new format: type,filename_line_n,hash
         skip_entries =
           new_fingerprints
           |> Enum.map(fn fingerprint ->
@@ -502,7 +502,7 @@ defmodule Sobelow do
 
                 "#{finding.type},#{filename}:#{finding.vuln_line_no},#{fingerprint}"
               nil ->
-                # Fallback to old format if we can't find the finding
+                # Should not happen, each fingerprint should have a corresponding finding
                 fingerprint
             end
           end)
@@ -529,13 +529,13 @@ defmodule Sobelow do
   defp load_ignored_fingerprints({:ok, line}, iofile) do
     line_str = to_string(line) |> String.trim()
 
-    # Parse line - could be old format (just hash) or new format (type,filename:line,hash)
+    # Parse line - could be old format (just hash) or new format (type,filename_line_n,hash)
     fingerprint = case String.split(line_str, ",") do
       [fingerprint] when fingerprint != "" ->
         # Old format: just the fingerprint hash
         fingerprint
-      [_type, _filename_line_no, fingerprint] when fingerprint != "" ->
-        # New format: type,filename,line,hash - extract just the hash
+      [_type, _filename_line_n, fingerprint] when fingerprint != "" ->
+        # New format: type,filename_line_n,phash2 - extract phash2
         fingerprint
       _ ->
         # Invalid line, skip it

--- a/lib/sobelow.ex
+++ b/lib/sobelow.ex
@@ -218,6 +218,7 @@ defmodule Sobelow do
   def loggable?(%Finding{} = finding, severity) do
     legacy_skip = finding.legacy_fingerprint && Fingerprint.member?(finding.legacy_fingerprint)
     new_skip = finding.fingerprint && Fingerprint.member?(finding.fingerprint)
+
     !(get_env(:skip) && (new_skip || legacy_skip)) &&
       meets_threshold?(severity)
   end
@@ -501,12 +502,12 @@ defmodule Sobelow do
                   |> Utils.normalize_path()
 
                 "#{finding.type},#{filename}:#{finding.vuln_line_no},#{fingerprint}"
+
               nil ->
                 # Should not happen, each fingerprint should have a corresponding finding
                 fingerprint
             end
           end)
-
 
         {:ok, iofile} = :file.open(cfile, [:append])
         entries_str = Enum.join(skip_entries, "\n")
@@ -530,17 +531,20 @@ defmodule Sobelow do
     line_str = to_string(line) |> String.trim()
 
     # Parse line - could be old format (just hash) or new format (type,filename_line_n,hash)
-    fingerprint = case String.split(line_str, ",") do
-      [fingerprint] when fingerprint != "" ->
-        # Old format: just the fingerprint hash
-        fingerprint
-      [_type, _filename_line_n, fingerprint] when fingerprint != "" ->
-        # New format: type,filename_line_n,phash2 - extract phash2
-        fingerprint
-      _ ->
-        # Invalid line, skip it
-        nil
-    end
+    fingerprint =
+      case String.split(line_str, ",") do
+        [fingerprint] when fingerprint != "" ->
+          # Old format: just the fingerprint hash
+          fingerprint
+
+        [_type, _filename_line_n, fingerprint] when fingerprint != "" ->
+          # New format: type,filename_line_n,phash2 - extract phash2
+          fingerprint
+
+        _ ->
+          # Invalid line, skip it
+          nil
+      end
 
     if fingerprint, do: Fingerprint.put_ignore(fingerprint)
     :file.read_line(iofile) |> load_ignored_fingerprints(iofile)

--- a/lib/sobelow/finding.ex
+++ b/lib/sobelow/finding.ex
@@ -12,7 +12,8 @@ defmodule Sobelow.Finding do
     :fun_name,
     :fun_line_no,
     :fun_source,
-    :fingerprint
+    :fingerprint,
+    :legacy_fingerprint
   ]
 
   alias Sobelow.Utils
@@ -42,10 +43,22 @@ defmodule Sobelow.Finding do
   end
 
   def fetch_fingerprint(%Sobelow.Finding{} = finding) do
-    %{finding | fingerprint: fingerprint(finding)}
+    %{finding | fingerprint: fingerprint(finding), legacy_fingerprint: legacy_fingerprint(finding)}
   end
 
   def fingerprint(%Sobelow.Finding{} = finding) do
+    filename =
+      Utils.get_root()
+      |> Utils.normalize_path()
+      |> (&String.replace_prefix(finding.filename, &1, "")).()
+      |> Utils.normalize_path()
+
+    [finding.type, finding.vuln_source, filename, finding.vuln_line_no]
+    |> :erlang.phash2()
+    |> Integer.to_string(16)
+  end
+
+  def legacy_fingerprint(%Sobelow.Finding{} = finding) do
     filename =
       Utils.get_root()
       |> Utils.normalize_path()

--- a/lib/sobelow/finding.ex
+++ b/lib/sobelow/finding.ex
@@ -43,7 +43,11 @@ defmodule Sobelow.Finding do
   end
 
   def fetch_fingerprint(%Sobelow.Finding{} = finding) do
-    %{finding | fingerprint: fingerprint(finding), legacy_fingerprint: legacy_fingerprint(finding)}
+    %{
+      finding
+      | fingerprint: fingerprint(finding),
+        legacy_fingerprint: legacy_fingerprint(finding)
+    }
   end
 
   def fingerprint(%Sobelow.Finding{} = finding) do

--- a/lib/sobelow/print.ex
+++ b/lib/sobelow/print.ex
@@ -25,7 +25,7 @@ defmodule Sobelow.Print do
   end
 
   def print_finding_metadata(%Finding{} = finding) do
-    if Sobelow.loggable?(finding.fingerprint, finding.confidence) do
+    if Sobelow.loggable?(finding, finding.confidence) do
       do_print_finding_metadata(finding)
     end
   end
@@ -41,7 +41,7 @@ defmodule Sobelow.Print do
   end
 
   def print_custom_finding_metadata(%Finding{} = finding, headers) do
-    if Sobelow.loggable?(finding.fingerprint, finding.confidence) do
+    if Sobelow.loggable?(finding, finding.confidence) do
       do_print_custom_finding_metadata(finding, headers)
     end
   end
@@ -65,7 +65,7 @@ defmodule Sobelow.Print do
   end
 
   defp print_compact_finding(finding, details) do
-    if Sobelow.loggable?(finding.fingerprint, finding.confidence) do
+    if Sobelow.loggable?(finding, finding.confidence) do
       do_print_compact_finding(details, finding.confidence)
     end
   end
@@ -89,7 +89,7 @@ defmodule Sobelow.Print do
   end
 
   defp print_flycheck_finding(finding, details) do
-    if Sobelow.loggable?(finding.fingerprint, finding.confidence) do
+    if Sobelow.loggable?(finding, finding.confidence) do
       do_print_flycheck_finding(details, finding.confidence)
     end
   end


### PR DESCRIPTION
Fix for https://github.com/nccgroup/sobelow/issues/147 using phash2, to avoid the problem of different binary values for the same term across different machines. 

Old `.sobelow-skips` file:

```
5550974065FBAE782CE8F7937AA89C0B
725B87092FFBE632F9E642C42BCE7D51
A20CDB95ED23D7EE422679143CB4A630
```

New `.sobelow-skips` file:

```
Config.HTTPS: HTTPS Not Enabled,config/prod.exs:0,2B5C077
Config.CSP: Missing Content-Security-Policy,lib/carafe_web/router.ex:21,3654153
Config.CSRFRoute: CSRF via Action Reuse,lib/carafe_web/router.ex:99,7FE447
Config.CSRF: Missing CSRF Protections,lib/carafe_web/router.ex:16,CC3F22
```

It is okay to have both formats in the same file:

```
5550974065FBAE782CE8F7937AA89C0B
725B87092FFBE632F9E642C42BCE7D51
Config.HTTPS: HTTPS Not Enabled,config/prod.exs:0,2B5C077
```

Goals for this PR:
1. Use phash2 on all new `.sobelow-skips` entries.
2. Maintain backwards compatibility with md5 hashes. The performance impact of doing this seems negligible.
3. Encourage Sobelow users to switch over to the new format, where context about each finding can be found in `.sobelow-skips`.
