### PR TITLE
Fix FunctionClauseError with empty .sobelow-conf files

### DIFF
--- a/lib/mix/tasks/sobelow.ex
+++ b/lib/mix/tasks/sobelow.ex
@@ -135,8 +135,13 @@ defmodule Mix.Tasks.Sobelow do
     opts =
       if conf_file? do
         {:ok, file_opts} = File.read!(conf_file) |> Code.string_to_quoted()
-        # CLI args take precedence
-        Keyword.merge(file_opts, opts)
+        # Merge if the config file contains a valid keyword list (ie, isn't empty)
+        if Keyword.keyword?(file_opts) do
+          # CLI args take precedence
+          Keyword.merge(file_opts, opts)
+        else
+          opts
+        end
       else
         opts
       end


### PR DESCRIPTION
connects to #21 

###Problem

Running Sobelow 0.14.1 with a blank .sobelow-conf file causes a crash with FunctionClauseError in Keyword.merge/2. The function receives {:__block__, [], []} as the first argument instead of a list.

### Root Cause

When Code.string_to_quoted/1 parses an empty file, it returns {:ok, {:__block__, [], []}} (an empty AST block), not {:ok, []} (an empty keyword list). This causes Keyword.merge/2 to fail since it expects both arguments to be lists.

###Solution

Use Keyword.keyword?/1 to validate that the parsed config file is a valid keyword list before attempting to merge. If the file is empty or contains invalid data, fall back to CLI options only.