### PR TITLE
Reduce churn: Sort lines in .sobelow-skips file by their value instead of the findings’ fingerprints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,14 @@
       `conn.${atom_to_string(field)}`.
     * `.sobelow-conf` keys are now genuinely sorted alphabetically.
   * Enhancements
+    * `.sobelow-skips` is now written in sorted order, so regenerating it after
+      fixing or adding a finding produces a small diff instead of reshuffling the
+      file. Entries sort by type, file, and line number — numerically, so line 10
+      follows line 9 rather than line 1. The whole file is sorted, not just the
+      newly added entries, so the ordering holds however many times it is
+      regenerated. Comments and pre-v0.14 bare-fingerprint lines are preserved.
+      Pass `--legacy-skips` for the previous append-only behaviour, which never
+      rewrites lines it did not add.
     * `# sobelow_skip` comments now work on Phoenix router pipelines, not just
       functions. This makes `Config.CSRF`, `Config.Headers`, and `Config.CSP`
       suppressible per pipeline instead of only via `--mark-skip-all`, so an API

--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ relative to the application root.
 
   * `--clear-skip` - Clear configuration created by `--mark-skip-all`.
 
+  * `--legacy-skips` - Append to `.sobelow-skips` rather than rewriting it in
+  sorted order. Only needed if you have tooling that relies on the file being
+  append-only.
+
   * `--skip` - Ignore findings that have been marked for skipping. See [False Positives](#false-positives)
   for more information.
 

--- a/lib/mix/tasks/sobelow.ex
+++ b/lib/mix/tasks/sobelow.ex
@@ -22,6 +22,7 @@ defmodule Mix.Tasks.Sobelow do
   * `--strict` - Exit when bad syntax is encountered
   * `--mark-skip-all` - Mark all printed findings as skippable
   * `--clear-skip` - Clear configuration added by `--mark-skip-all`
+  * `--legacy-skips` - Append to `.sobelow-skips` instead of rewriting it sorted
   * `--skip` - Skip functions/Phoenix pipelines flagged with `#sobelow_skip` or tagged with `--mark-skip-all`
   * `--router` - Specify router location
   * `--exit` - Return non-zero exit status
@@ -97,6 +98,7 @@ defmodule Mix.Tasks.Sobelow do
     skip: :boolean,
     mark_skip_all: :boolean,
     clear_skip: :boolean,
+    legacy_skips: :boolean,
     router: :string,
     exit: :string,
     format: :string,
@@ -157,6 +159,7 @@ defmodule Mix.Tasks.Sobelow do
     set_env(:skip, skip)
     set_env(:mark_skip_all, mark_skip_all)
     set_env(:clear_skip, clear_skip)
+    set_env(:legacy_skips, Keyword.get(opts, :legacy_skips, false))
     set_env(:router, router)
     set_env(:exit_on, exit_on)
     set_env(:format, format)

--- a/lib/sobelow.ex
+++ b/lib/sobelow.ex
@@ -540,12 +540,80 @@ defmodule Sobelow do
                 fingerprint
             end
           end)
-          |> Enum.sort()
 
-        {:ok, iofile} = :file.open(cfile, [:append])
-        entries_str = Enum.join(skip_entries, "\n")
-        :file.write(iofile, ["\n", entries_str])
-        :file.close(iofile)
+        write_skips(cfile, skip_entries)
+    end
+  end
+
+  defp write_skips(cfile, entries) do
+    if get_env(:legacy_skips) do
+      append_skips(cfile, entries)
+    else
+      rewrite_skips(cfile, entries)
+    end
+  end
+
+  # The historical behaviour: never touch what is already in the file, only add
+  # to the end of it. Kept behind `--legacy-skips` for anyone whose tooling
+  # depends on the file being append-only.
+  defp append_skips(cfile, entries) do
+    {:ok, iofile} = :file.open(cfile, [:append])
+    :file.write(iofile, ["\n", entries |> sort_skips() |> Enum.join("\n")])
+    :file.close(iofile)
+  end
+
+  # Sorting only the newly appended entries leaves the file as a series of
+  # independently sorted blocks, so the churn this avoids only holds for a file
+  # written in one go. Merging with what is already there and rewriting keeps the
+  # whole file ordered however many times it is regenerated.
+  defp rewrite_skips(cfile, entries) do
+    existing =
+      case File.read(cfile) do
+        {:ok, contents} -> contents |> String.split("\n") |> Enum.map(&String.trim/1)
+        {:error, _} -> []
+      end
+
+    lines =
+      (existing ++ entries)
+      |> Enum.reject(&(&1 == ""))
+      |> Enum.uniq()
+      |> sort_skips()
+
+    File.write!(cfile, Enum.join(lines, "\n") <> "\n")
+  end
+
+  defp sort_skips(entries), do: Enum.sort_by(entries, &skip_sort_key/1)
+
+  # Sorting the raw string would put line 10 before line 2, so an edit that
+  # renumbers findings reshuffles the file — exactly the churn sorting is meant
+  # to remove. Ordering on the parsed location keeps entries in place and lets
+  # only their line numbers change.
+  #
+  # Comments are kept at the top, where a header note belongs. Bare fingerprints
+  # are the pre-v0.14 format and sort last, since they carry no location to sort
+  # on. Nothing is ever dropped: a rewrite preserves every line it found.
+  defp skip_sort_key("#" <> _ = comment), do: {0, comment, "", 0, ""}
+
+  defp skip_sort_key(entry) do
+    case String.split(entry, ",") do
+      [type, location, fingerprint] ->
+        {file, line_no} = split_skip_location(location)
+        {1, type, file, line_no, fingerprint}
+
+      [fingerprint] ->
+        {2, "", "", 0, fingerprint}
+
+      _ ->
+        {3, entry, "", 0, ""}
+    end
+  end
+
+  defp split_skip_location(location) do
+    segments = String.split(location, ":")
+
+    case segments |> List.last() |> Integer.parse() do
+      {line_no, ""} -> {segments |> Enum.drop(-1) |> Enum.join(":"), line_no}
+      _ -> {location, 0}
     end
   end
 

--- a/lib/sobelow.ex
+++ b/lib/sobelow.ex
@@ -540,6 +540,7 @@ defmodule Sobelow do
                 fingerprint
             end
           end)
+          |> Enum.sort()
 
         {:ok, iofile} = :file.open(cfile, [:append])
         entries_str = Enum.join(skip_entries, "\n")

--- a/test/e2e/skips_file_test.exs
+++ b/test/e2e/skips_file_test.exs
@@ -1,0 +1,139 @@
+defmodule Sobelow.SkipsFileTest do
+  @moduledoc """
+  Coverage for the `.sobelow-skips` file written by `--mark-skip-all`.
+
+  The file is committed to a project's repository, so its layout is part of the
+  user-facing contract: it must round-trip, it must not lose lines it did not
+  write, and it must stay ordered so that regenerating it produces a small diff.
+  """
+  use Sobelow.ScanCase
+
+  @skips ".sobelow-skips"
+
+  defp skips_path(fixture), do: Path.join(fixture_path(fixture), @skips)
+
+  defp skip_lines(fixture) do
+    skips_path(fixture)
+    |> File.read!()
+    |> String.split("\n")
+    |> Enum.reject(&(&1 == ""))
+  end
+
+  # `--mark-skip-all` writes into the fixture app, so clean up after each test.
+  setup do
+    on_exit(fn -> File.rm_rf!(skips_path("basic")) end)
+    :ok
+  end
+
+  defp mark_skips(fixture, opts \\ []) do
+    scan_io(fixture, Keyword.merge([mark_skip_all: true], opts))
+  end
+
+  test "recorded skips suppress every finding on the next scan" do
+    assert findings(scan("basic")) != []
+
+    mark_skips("basic")
+
+    assert findings(scan("basic", skip: true)) == []
+  end
+
+  test "entries are written sorted" do
+    mark_skips("basic")
+
+    lines = skip_lines("basic")
+
+    assert lines != []
+    assert lines == Enum.sort_by(lines, & &1)
+  end
+
+  # Sorting the raw strings would order line 10 before line 2, so an edit that
+  # renumbers findings would reshuffle the file rather than just update it.
+  test "entries in one file are ordered by line number numerically" do
+    contents =
+      Enum.map_join(2..12, "\n", fn _ ->
+        ~s|  def a#{System.unique_integer([:positive])}(conn, %{"p" => p}), do: send_file(conn, 200, p)|
+      end)
+
+    temp_fixture_file(
+      "basic",
+      "lib/basic_web/controllers/many_controller.ex",
+      "defmodule BasicWeb.ManyController do\n#{contents}\nend\n"
+    )
+
+    mark_skips("basic")
+
+    line_numbers =
+      "basic"
+      |> skip_lines()
+      |> Enum.filter(&String.contains?(&1, "many_controller.ex"))
+      |> Enum.map(fn line ->
+        [_type, location, _fingerprint] = String.split(line, ",")
+        location |> String.split(":") |> List.last() |> String.to_integer()
+      end)
+
+    assert length(line_numbers) > 9, "expected enough findings to span one and two digits"
+    assert line_numbers == Enum.sort(line_numbers)
+  end
+
+  describe "regenerating an existing file" do
+    test "keeps the whole file sorted, not just the new entries" do
+      mark_skips("basic")
+
+      # A finding whose type sorts before everything already recorded.
+      temp_fixture_file("basic", "lib/basic_web/controllers/ci_controller.ex", """
+      defmodule BasicWeb.CIController do
+        def run(conn, %{"cmd" => cmd}) do
+          System.cmd(cmd, [])
+          conn
+        end
+      end
+      """)
+
+      mark_skips("basic")
+
+      lines = skip_lines("basic")
+
+      assert Enum.any?(lines, &String.starts_with?(&1, "CI.System"))
+      assert lines == Enum.sort_by(lines, & &1)
+    end
+
+    test "preserves comments at the top and legacy bare fingerprints at the end" do
+      File.write!(skips_path("basic"), "# reviewed 2026-01-01\nDEADBEEF\n")
+
+      mark_skips("basic")
+
+      lines = skip_lines("basic")
+
+      assert hd(lines) == "# reviewed 2026-01-01"
+      assert List.last(lines) == "DEADBEEF"
+    end
+
+    test "does not duplicate entries when run twice with no new findings" do
+      mark_skips("basic")
+      first = skip_lines("basic")
+
+      mark_skips("basic")
+
+      assert skip_lines("basic") == first
+    end
+  end
+
+  describe "--legacy-skips" do
+    test "appends without rewriting what is already in the file" do
+      File.write!(skips_path("basic"), "ZZZZZZZ\n")
+
+      mark_skips("basic", legacy_skips: true)
+
+      lines = skip_lines("basic")
+
+      assert hd(lines) == "ZZZZZZZ", "existing content must not be reordered"
+      assert length(lines) > 1
+    end
+
+    test "recorded skips still round-trip" do
+      mark_skips("basic", legacy_skips: true)
+
+      assert findings(scan("basic", skip: true)) == []
+    end
+  end
+end

--- a/test/mix_task_test.exs
+++ b/test/mix_task_test.exs
@@ -19,6 +19,7 @@ defmodule SobelowTest.MixTaskTest do
     :format,
     :ignored,
     :ignored_files,
+    :legacy_skips,
     :out,
     :private,
     :root,
@@ -33,6 +34,16 @@ defmodule SobelowTest.MixTaskTest do
     capture_io(fn -> Mix.Tasks.Sobelow.run(argv ++ ["--version", "--private"]) end)
 
     Map.new(@env_keys, &{&1, Application.get_env(:sobelow, &1)})
+  end
+
+  describe "--legacy-skips" do
+    test "defaults to off, so the skips file is rewritten sorted" do
+      assert parse([]).legacy_skips == false
+    end
+
+    test "is enabled by the flag" do
+      assert parse(["--legacy-skips"]).legacy_skips == true
+    end
   end
 
   describe "defaults" do

--- a/test/support/scan_case.ex
+++ b/test/support/scan_case.ex
@@ -27,6 +27,7 @@ defmodule Sobelow.ScanCase do
     format: "json",
     ignored: [],
     ignored_files: [],
+    legacy_skips: false,
     mark_skip_all: false,
     out: nil,
     private: true,

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -86,7 +86,11 @@ mix sobelow --skip            # scan, ignoring those
 mix sobelow --clear-skip      # discard the recorded skips
 ```
 
-Commit `.sobelow-skips` so the whole team and CI share the same baseline.
+Commit `.sobelow-skips` so the whole team and CI share the same baseline. The file
+is rewritten in sorted order each time it is regenerated, so re-running
+`--mark-skip-all` after fixing or adding a finding produces a small, readable diff
+rather than reshuffling the file. Pass `--legacy-skips` if you need the older
+append-only behaviour, which never rewrites lines it did not add.
 
 Prefer `# sobelow_skip` with an explicit module list over `--mark-skip-all` when you
 have only a handful of false positives — it documents the decision at the code, and


### PR DESCRIPTION
Hello! First of all, thank you very much for Sobelow.

This reduces churn in a project’s .sobelow-skips file when stored in git because adding/removing a line in a source file before a finding doesn’t move its respective .sobelow-skips file entry to a completely different line.

Note: It uses the simplest approach sorting the lines by their value as a whole instead of ordering by the parts of a finding (type, file path, line no., fingerprint). This could lead to two lines (f.i. 42 and 111) of the same type and in the same source file to appear in “incorrect” order. It still achieves the goal of reducing churn.

Let me know if the sorting should be more sophisticated.