### PR TITLE
Allow possibility to remove missing router warning (issue #25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@
       `conn.${atom_to_string(field)}`.
     * `.sobelow-conf` keys are now genuinely sorted alphabetically.
   * Enhancements
+    * Added `--no-router`, for scanning a project that has no Phoenix router.
+      Sobelow warned that it could not find one and offered no way to silence it,
+      which was noise for plain Elixir libraries. It is shorthand for
+      `--router :none`, which can also be set in `.sobelow-conf` as
+      `router: :none`. The router-dependent checks are skipped either way.
     * `.sobelow-skips` is now written in sorted order, so regenerating it after
       fixing or adding a finding produces a small diff instead of reshuffling the
       file. Entries sort by type, file, and line number — numerically, so line 10

--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ relative to the application root.
   used if the router location is non-standard. Accepts a path
   argument, e.g. `my/strange/router.ex`.
 
+  * `--no-router` - Scan a project that has no Phoenix router, such as a plain
+  Elixir library. Sobelow otherwise warns that it cannot find one. The
+  router-dependent checks (`Config.CSRF`, `Config.CSRFRoute`, `Config.Headers`,
+  and `Config.CSP`) are skipped either way, since there is nothing for them to
+  inspect. This is shorthand for `--router :none`, which can also be set in
+  `.sobelow-conf` as `router: :none`.
+
   * `--exit` - Return non-zero exit status at or above a confidence
   threshold of `low`, `medium`, or `high`. Defaults to `false` which returns a zero exit status
 

--- a/lib/mix/tasks/sobelow.ex
+++ b/lib/mix/tasks/sobelow.ex
@@ -25,6 +25,8 @@ defmodule Mix.Tasks.Sobelow do
   * `--legacy-skips` - Append to `.sobelow-skips` instead of rewriting it sorted
   * `--skip` - Skip functions/Phoenix pipelines flagged with `#sobelow_skip` or tagged with `--mark-skip-all`
   * `--router` - Specify router location
+  * `--no-router` - Scan a project that has no Phoenix router, suppressing the
+  "cannot find the router" warning. Equivalent to `--router :none`
   * `--exit` - Return non-zero exit status
   * `--threshold` - Only return findings at or above a given confidence level
   * `--format` - Specify findings output format
@@ -100,6 +102,7 @@ defmodule Mix.Tasks.Sobelow do
     clear_skip: :boolean,
     legacy_skips: :boolean,
     router: :string,
+    no_router: :boolean,
     exit: :string,
     format: :string,
     config: :boolean,
@@ -273,7 +276,14 @@ defmodule Mix.Tasks.Sobelow do
     skip = Keyword.get(opts, :skip, false)
     mark_skip_all = Keyword.get(opts, :mark_skip_all, false)
     clear_skip = Keyword.get(opts, :clear_skip, false)
-    router = Keyword.get(opts, :router)
+    # `--no-router` is the discoverable spelling of `--router :none`. Normalising
+    # it here keeps `:router` the single source of truth, so `--save-config`
+    # records it and a `.sobelow-conf` can express it too.
+    router =
+      if Keyword.get(opts, :no_router, false),
+        do: :none,
+        else: Keyword.get(opts, :router)
+
     out = Keyword.get(opts, :out)
     version = Keyword.get(opts, :version, false)
 

--- a/lib/sobelow.ex
+++ b/lib/sobelow.ex
@@ -342,6 +342,8 @@ defmodule Sobelow do
     case get_env(:router) do
       nil -> ""
       "" -> ""
+      :none -> ""
+      ":none" -> ""
       router -> Path.expand(router)
     end
   end
@@ -472,7 +474,9 @@ defmodule Sobelow do
     please use the `--router` flag to specify the router's location.
     """
 
-    IO.puts(:stderr, message)
+    if get_env(:router) not in [":none", :none] do
+      IO.puts(:stderr, message)
+    end
     ignored = get_env(:ignored)
 
     Application.put_env(

--- a/lib/sobelow.ex
+++ b/lib/sobelow.ex
@@ -338,17 +338,30 @@ defmodule Sobelow do
     """
   end
 
-  defp get_router("", true) do
+  # `--no-router`, `--router :none`, and `router: :none` in `.sobelow-conf` all
+  # declare that the project has no router. The CLI can only ever produce the
+  # string, while a config file holds the atom, so both spellings are accepted.
+  defp router_disabled?, do: get_env(:router) in [:none, ":none"]
+
+  # Checked before either clause below: the second pipes through `Path.expand/1`,
+  # which raises on an atom.
+  defp get_router(tmp_default_router, phx_post_1_2?) do
+    if router_disabled?() do
+      ""
+    else
+      do_get_router(tmp_default_router, phx_post_1_2?)
+    end
+  end
+
+  defp do_get_router("", true) do
     case get_env(:router) do
       nil -> ""
       "" -> ""
-      :none -> ""
-      ":none" -> ""
       router -> Path.expand(router)
     end
   end
 
-  defp get_router(tmp_default_router, _) do
+  defp do_get_router(tmp_default_router, _) do
     case get_env(:router) do
       nil -> tmp_default_router
       "" -> tmp_default_router
@@ -474,9 +487,10 @@ defmodule Sobelow do
     please use the `--router` flag to specify the router's location.
     """
 
-    if get_env(:router) not in [":none", :none] do
-      IO.puts(:stderr, message)
-    end
+    if !router_disabled?(), do: IO.puts(:stderr, message)
+
+    # The router checks are dropped either way — without a router there is
+    # nothing for them to inspect.
     ignored = get_env(:ignored)
 
     Application.put_env(

--- a/test/e2e/no_router_test.exs
+++ b/test/e2e/no_router_test.exs
@@ -1,0 +1,48 @@
+defmodule Sobelow.NoRouterTest do
+  @moduledoc """
+  Coverage for scanning a project that has no Phoenix router.
+
+  Sobelow warns when it cannot find a router, which is noise for a project that
+  legitimately has none. `--no-router` (and the `:none` router value it is
+  shorthand for) suppresses it.
+
+  Both fixture layouts matter: a `web/` directory makes Sobelow treat a project
+  as pre-Phoenix 1.3, which resolves the router through a different code path.
+  """
+  use Sobelow.ScanCase
+
+  @warning "cannot find the router"
+
+  defp warned?(fixture, opts) do
+    {_stdout, stderr} = scan_io(fixture, opts)
+    stderr =~ @warning
+  end
+
+  for fixture <- ["no_router", "no_router_legacy"] do
+    describe "#{fixture}" do
+      test "warns by default" do
+        assert warned?(unquote(fixture), [])
+      end
+
+      test "--router :none suppresses the warning" do
+        refute warned?(unquote(fixture), router: ":none")
+      end
+
+      # A `.sobelow-conf` holds a real atom rather than the string the CLI
+      # produces. This used to raise from `Path.expand/1` on the `web/` layout.
+      test "a :none atom from a config file suppresses the warning" do
+        refute warned?(unquote(fixture), router: :none)
+      end
+
+      test "an explicit nil router still warns" do
+        assert warned?(unquote(fixture), router: nil)
+      end
+
+      test "the scan still completes and reports findings normally" do
+        report = scan(unquote(fixture), router: ":none", format: "json")
+
+        assert Map.has_key?(report, "findings")
+      end
+    end
+  end
+end

--- a/test/fixtures/apps/no_router/lib/no_router.ex
+++ b/test/fixtures/apps/no_router/lib/no_router.ex
@@ -1,0 +1,4 @@
+# A plain Elixir project: no Phoenix, and therefore no router to find.
+defmodule NoRouter do
+  def hello, do: :world
+end

--- a/test/fixtures/apps/no_router/mix.exs
+++ b/test/fixtures/apps/no_router/mix.exs
@@ -1,0 +1,10 @@
+defmodule NoRouter.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :no_router,
+      version: "0.1.0"
+    ]
+  end
+end

--- a/test/fixtures/apps/no_router_legacy/lib/no_router_legacy.ex
+++ b/test/fixtures/apps/no_router_legacy/lib/no_router_legacy.ex
@@ -1,0 +1,3 @@
+defmodule NoRouterLegacy do
+  def hello, do: :world
+end

--- a/test/fixtures/apps/no_router_legacy/mix.exs
+++ b/test/fixtures/apps/no_router_legacy/mix.exs
@@ -1,0 +1,10 @@
+defmodule NoRouterLegacy.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :no_router_legacy,
+      version: "0.1.0"
+    ]
+  end
+end

--- a/test/fixtures/apps/no_router_legacy/web/no_router_legacy_web.ex
+++ b/test/fixtures/apps/no_router_legacy/web/no_router_legacy_web.ex
@@ -1,0 +1,6 @@
+# The presence of a `web/` directory is what makes Sobelow treat a project as
+# pre-Phoenix 1.3, which selects a different router-resolution path. There is
+# still no router here.
+defmodule NoRouterLegacyWeb do
+  def hello, do: :world
+end

--- a/test/mix_task_test.exs
+++ b/test/mix_task_test.exs
@@ -36,6 +36,24 @@ defmodule SobelowTest.MixTaskTest do
     Map.new(@env_keys, &{&1, Application.get_env(:sobelow, &1)})
   end
 
+  describe "--no-router" do
+    test "is normalised to a :none router, so it round-trips through --save-config" do
+      assert parse(["--no-router"]).router == :none
+    end
+
+    test "leaves the router unset when absent" do
+      assert parse([]).router == nil
+    end
+
+    test "does not disturb an explicit router path" do
+      assert parse(["--router", "lib/my_web/router.ex"]).router == "lib/my_web/router.ex"
+    end
+
+    test "takes precedence over an explicit router path" do
+      assert parse(["--router", "lib/my_web/router.ex", "--no-router"]).router == :none
+    end
+  end
+
   describe "--legacy-skips" do
     test "defaults to off, so the skips file is rewritten sorted" do
       assert parse([]).legacy_skips == false

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -149,6 +149,10 @@ Other useful flags:
 - `--compact` / `--flycheck` — single-line findings for editors and tooling.
 - `--strict` — treat a file Sobelow cannot parse as a hard error (exit 2) instead of
   skipping it. Without it, unparseable files are silently skipped.
+- `--no-router` — for a project with no Phoenix router, such as a plain Elixir
+  library. Without it Sobelow warns that it cannot find one, on every run. The
+  router-dependent checks are skipped either way. Set it in `.sobelow-conf` as
+  `router: :none`.
 
 ## What it will and will not find
 


### PR DESCRIPTION
This small pull request fixes issue #25 so we can get a warning free output even for non-phoenix projects