### PR TITLE
fix: honor CSRF skips on router pipelines

### DIFF
--- a/lib/sobelow/config.ex
+++ b/lib/sobelow/config.ex
@@ -111,6 +111,34 @@ defmodule Sobelow.Config do
     acc
   end
 
+  def get_pipelines_with_skips(filepath) do
+    ast = Parse.ast(filepath)
+
+    {_, acc} =
+      Macro.prewalk(ast, [], fn
+        {:@, _, [{:sobelow_skip, _, [skips]}]} = ast, acc ->
+          {ast, [{:skip, skips} | acc]}
+
+        {:pipeline, _, _} = ast, acc ->
+          {ast, [{:pipeline, ast} | acc]}
+
+        ast, acc ->
+          {ast, acc}
+      end)
+
+    combine_pipeline_skips(acc)
+  end
+
+  defp combine_pipeline_skips([]), do: []
+
+  defp combine_pipeline_skips([{:pipeline, pipeline}, {:skip, skips} | rest]),
+    do: [{pipeline, skips} | combine_pipeline_skips(rest)]
+
+  defp combine_pipeline_skips([{:pipeline, pipeline} | rest]),
+    do: [{pipeline, []} | combine_pipeline_skips(rest)]
+
+  defp combine_pipeline_skips([{:skip, _skips} | rest]), do: combine_pipeline_skips(rest)
+
   def get_plug_list(block) do
     case block do
       {:__block__, _, list} -> list

--- a/lib/sobelow/config/csrf.ex
+++ b/lib/sobelow/config/csrf.ex
@@ -27,13 +27,20 @@ defmodule Sobelow.Config.CSRF do
   def run(router) do
     finding = Finding.init(@finding_type, Utils.normalize_path(router))
 
-    Config.get_pipelines(router)
+    Config.get_pipelines_with_skips(router)
+    |> Stream.reject(&skipped?/1)
+    |> Stream.map(fn {pipeline, _skips} -> pipeline end)
     |> Stream.filter(&vuln_pipeline?/1)
     |> Enum.each(&add_finding(&1, finding))
   end
 
   defp vuln_pipeline?(pipeline) do
     Config.vuln_pipeline?(pipeline, :csrf)
+  end
+
+  defp skipped?({_pipeline, skips}) do
+    skip_mods = Enum.map(skips, &Sobelow.get_mod/1)
+    Sobelow.Config in skip_mods or __MODULE__ in skip_mods
   end
 
   defp add_finding({:pipeline, _, [pipeline_name, _]} = pipeline, finding) do

--- a/test/config/csrf_test.exs
+++ b/test/config/csrf_test.exs
@@ -29,4 +29,17 @@ defmodule SobelowTest.Config.CSRFTest do
     assert Config.get_pipelines(router)
            |> Enum.any?(&Config.vuln_pipeline?(&1, :csrf))
   end
+
+  test "tracks sobelow_skip annotations before router pipelines" do
+    Application.put_env(:sobelow, :skip, true)
+
+    on_exit(fn ->
+      Application.delete_env(:sobelow, :skip)
+    end)
+
+    router = "./test/fixtures/csrf/skipped_bad_router.ex"
+
+    assert [{pipeline, ["Config.CSRF"]}] = Config.get_pipelines_with_skips(router)
+    assert Config.vuln_pipeline?(pipeline, :csrf)
+  end
 end

--- a/test/fixtures/csrf/skipped_bad_router.ex
+++ b/test/fixtures/csrf/skipped_bad_router.ex
@@ -1,0 +1,11 @@
+# Router is missing plug :protect_from_forgery
+defmodule BadRouter do
+  @moduledoc false
+
+  # sobelow_skip ["Config.CSRF"]
+  pipeline :browser do
+    plug(:accepts, ["html"])
+    plug(:fetch_session)
+    plug(:fetch_flash)
+  end
+end


### PR DESCRIPTION
## Summary
- track `# sobelow_skip [...]` annotations adjacent to router pipelines
- skip `Config.CSRF` findings for annotated vulnerable pipelines
- add a regression fixture for a skipped bad browser pipeline

## Tests
- `mix test test/config/csrf_test.exs`
