### PR TITLE
Remove redundant is_atom check flagged by Elixir 1.20 type checker

### DIFF
--- a/lib/sobelow/finding_log.ex
+++ b/lib/sobelow/finding_log.ex
@@ -112,8 +112,7 @@ defmodule Sobelow.FindingLog do
 
     # 1) We got a module and exports id/0 ─ call it via apply/3
     rule_id =
-      if is_atom(mod_struct) and
-           Code.ensure_loaded?(mod_struct) and
+      if Code.ensure_loaded?(mod_struct) and
            function_exported?(mod_struct, :id, 0) do
         apply(mod_struct, :id, [])
       else


### PR DESCRIPTION
## Summary

Elixir 1.20's new type checker flags a warning in `Sobelow.FindingLog.format_sarif/1`:

```
warning: the following conditional expression will always succeed:
    is_atom(mod_struct)
because it evaluates to:
    dynamic(true)
```

`Sobelow.get_mod/1` (`lib/sobelow.ex`) only ever returns one of the known `Sobelow.*` module atoms, or `nil` from its catch-all clause. Since `nil` is itself an atom, `is_atom(mod_struct)` can never be false for any value `get_mod/1` produces — the type checker has correctly proven the check is dead code.

## Fix

Removed the redundant `is_atom(mod_struct) and` guard. The subsequent `Code.ensure_loaded?/1` and `function_exported?/2` calls already handle the `nil` case correctly (both simply return `false` for `nil`), so behavior is unchanged — this is a pure warning fix, not a behavior change.

## Test plan

- [x] `mix compile --force` — the `is_atom` type warning no longer appears; no new warnings introduced for the `sobelow` app
- [x] `mix test` — all 103 tests pass (including `test/sarif_test.exs`)
- [x] `mix format` — no formatting changes needed