### PR TITLE
feat: Support inline `# sobelow_skip` comments on Phoenix pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,17 @@ def vuln_func(...) do
 end
 ```
 
+The same syntax works for Phoenix router pipelines, which is
+useful for configuration findings such as `Config.CSRF` and
+`Config.Headers`:
+
+```elixir
+# sobelow_skip ["Config.Headers"]
+pipeline :browser do
+  ...
+end
+```
+
 When integrating Sobelow into a new project, there can be a
 large number of false positives. To mark all printed findings
 as false positives, run sobelow with the `--mark-skip-all` flag.
@@ -197,10 +208,9 @@ Sobelow with the `--skip` flag.
 
     $ mix sobelow --skip
 
-While `# sobelow_skip` comments can only mark function-level
-findings (and so cannot be used to skip configuration issues),
-the `--mark-skip-all` flag can be used to skip any finding
-type.
+While `# sobelow_skip` comments mark function- and pipeline-level
+findings, the `--mark-skip-all` flag can be used to skip any
+finding type.
 
 ## Modules
 Findings categories are broken up into modules. These modules

--- a/lib/mix/tasks/sobelow.ex
+++ b/lib/mix/tasks/sobelow.ex
@@ -22,7 +22,7 @@ defmodule Mix.Tasks.Sobelow do
   * `--strict` - Exit when bad syntax is encountered
   * `--mark-skip-all` - Mark all printed findings as skippable
   * `--clear-skip` - Clear configuration added by `--mark-skip-all`
-  * `--skip` - Skip functions flagged with `#sobelow_skip` or tagged with `--mark-skip-all`
+  * `--skip` - Skip functions/Phoenix pipelines flagged with `#sobelow_skip` or tagged with `--mark-skip-all`
   * `--router` - Specify router location
   * `--exit` - Return non-zero exit status
   * `--threshold` - Only return findings at or above a given confidence level

--- a/lib/sobelow/config.ex
+++ b/lib/sobelow/config.ex
@@ -106,10 +106,32 @@ defmodule Sobelow.Config do
   # Config utils
 
   def get_pipelines(filepath) do
-    ast = Parse.ast(filepath)
-    {_, acc} = Macro.prewalk(ast, [], &Parse.get_funs_of_type(&1, &2, :pipeline))
-    acc
+    filepath
+    |> get_pipelines_with_skips()
+    |> Enum.map(fn {pipeline, _skips} -> pipeline end)
   end
+
+  def get_unskipped_pipelines(filepath, check_mod) do
+    get_pipelines_with_skips(filepath)
+    |> Enum.reject(&skipped_pipeline?(&1, check_mod))
+    |> Enum.map(fn {pipeline, _skips} -> pipeline end)
+  end
+
+  defp get_pipelines_with_skips(filepath) do
+    filepath
+    |> Parse.ast()
+    |> Parse.get_pipelines_with_skips()
+  end
+
+  defp skipped_pipeline?({_pipeline, skips}, check_mod) when is_list(skips) do
+    Sobelow.get_env(:skip) &&
+      Enum.any?(skips, fn skip ->
+        mod = Sobelow.get_mod(skip)
+        mod == check_mod || mod == __MODULE__
+      end)
+  end
+
+  defp skipped_pipeline?(_, _), do: false
 
   def get_plug_list(block) do
     case block do

--- a/lib/sobelow/config/csp.ex
+++ b/lib/sobelow/config/csp.ex
@@ -26,6 +26,14 @@ defmodule Sobelow.Config.CSP do
   Content-Security-Policy checks can be ignored with the following command:
 
       $ mix sobelow -i Config.CSP
+
+  False positives can be ignored at the pipeline level by
+  adding a `# sobelow_skip` comment:
+
+      # sobelow_skip ["Config.CSP"]
+      pipeline :browser do
+        ...
+      end
   """
   alias Sobelow.Config
 
@@ -38,7 +46,7 @@ defmodule Sobelow.Config.CSP do
     meta_file = Parse.ast(router) |> Parse.get_meta_funs()
     finding = Finding.init(@finding_type, Utils.normalize_path(router))
 
-    Config.get_pipelines(router)
+    Config.get_unskipped_pipelines(router, __MODULE__)
     |> Enum.map(&check_vuln_pipeline(&1, meta_file))
     |> Enum.each(&maybe_add_finding(&1, finding))
   end

--- a/lib/sobelow/config/csrf.ex
+++ b/lib/sobelow/config/csrf.ex
@@ -16,6 +16,14 @@ defmodule Sobelow.Config.CSRF do
   CSRF checks can be ignored with the following command:
 
       $ mix sobelow -i Config.CSRF
+
+  False positives can be ignored at the pipeline level by
+  adding a `# sobelow_skip` comment:
+
+      # sobelow_skip ["Config.CSRF"]
+      pipeline :api do
+        ...
+      end
   """
   alias Sobelow.Config
 
@@ -27,7 +35,7 @@ defmodule Sobelow.Config.CSRF do
   def run(router) do
     finding = Finding.init(@finding_type, Utils.normalize_path(router))
 
-    Config.get_pipelines(router)
+    Config.get_unskipped_pipelines(router, __MODULE__)
     |> Stream.filter(&vuln_pipeline?/1)
     |> Enum.each(&add_finding(&1, finding))
   end

--- a/lib/sobelow/config/headers.ex
+++ b/lib/sobelow/config/headers.ex
@@ -14,6 +14,14 @@ defmodule Sobelow.Config.Headers do
   command:
 
       $ mix sobelow -i Config.Headers
+
+  False positives can be ignored at the pipeline level by
+  adding a `# sobelow_skip` comment:
+
+      # sobelow_skip ["Config.Headers"]
+      pipeline :browser do
+        ...
+      end
   """
   alias Sobelow.Config
 
@@ -25,7 +33,7 @@ defmodule Sobelow.Config.Headers do
   def run(router) do
     finding = Finding.init(@finding_type, Utils.normalize_path(router))
 
-    Config.get_pipelines(router)
+    Config.get_unskipped_pipelines(router, __MODULE__)
     |> Stream.filter(&vuln_pipeline?/1)
     |> Enum.each(&add_finding(&1, finding))
   end

--- a/lib/sobelow/parse.ex
+++ b/lib/sobelow/parse.ex
@@ -77,6 +77,47 @@ defmodule Sobelow.Parse do
     acc
   end
 
+  @doc false
+  # Collects `pipeline` macros with any immediately preceding `@sobelow_skip`
+  # attributes (converted from `# sobelow_skip` comments when `--skip` is set).
+  # Phoenix router pipelines are macros, not `def`/`defp`, so the normal
+  # function-level skip association does not apply to them.
+  def get_pipelines_with_skips(ast) do
+    {_, acc} = Macro.prewalk(ast, [], &collect_pipelines_with_skips/2)
+    acc
+  end
+
+  defp collect_pipelines_with_skips({:__block__, meta, stmts}, acc) when is_list(stmts) do
+    pipelines = associate_skips_with_pipelines(stmts)
+    {{:__block__, meta, stmts}, acc ++ pipelines}
+  end
+
+  # A module whose only expression is a pipeline has no surrounding `__block__`.
+  defp collect_pipelines_with_skips(
+         {:defmodule, meta, [alias_ast, [do: {:pipeline, _, _} = pipeline]]},
+         acc
+       ) do
+    {{:defmodule, meta, [alias_ast, [do: pipeline]]}, acc ++ [{pipeline, []}]}
+  end
+
+  defp collect_pipelines_with_skips(ast, acc), do: {ast, acc}
+
+  defp associate_skips_with_pipelines(statements) do
+    {pipelines, _pending_skips} =
+      Enum.reduce(statements, {[], []}, fn
+        {:@, _, [{:sobelow_skip, _, [skips]}]}, {acc, pending} when is_list(skips) ->
+          {acc, pending ++ skips}
+
+        {:pipeline, _, _} = pipeline, {acc, pending} ->
+          {[{pipeline, pending} | acc], []}
+
+        _, {acc, _pending} ->
+          {acc, []}
+      end)
+
+    Enum.reverse(pipelines)
+  end
+
   def get_meta_funs({:@, _, [{:sobelow_skip, _, _}]} = ast, acc) do
     if Sobelow.get_env(:skip) do
       {ast, Map.update!(acc, :def_funs, &[ast | &1])}

--- a/test/config/csp_test.exs
+++ b/test/config/csp_test.exs
@@ -51,6 +51,25 @@ defmodule SobelowTest.Config.CSPTest do
            |> Enum.any?(&vuln?/1)
   end
 
+  test "honors sobelow_skip on vulnerable pipelines" do
+    Application.put_env(:sobelow, :skip, true)
+    on_exit(fn -> Application.delete_env(:sobelow, :skip) end)
+
+    router = "./test/fixtures/csp/skipped_router.ex"
+
+    meta_file =
+      Parse.ast(router)
+      |> Parse.get_meta_funs()
+
+    vulnerable =
+      Config.get_unskipped_pipelines(router, CSP)
+      |> Enum.map(&CSP.check_vuln_pipeline(&1, meta_file))
+      |> Enum.filter(&vuln?/1)
+
+    # :browser is skipped, :other is not
+    assert [{true, _, _, {:pipeline, _, [:other, _]}}] = vulnerable
+  end
+
   defp vuln?({true, _, _, _}), do: true
   defp vuln?(_), do: false
 end

--- a/test/config/csrf_test.exs
+++ b/test/config/csrf_test.exs
@@ -29,4 +29,18 @@ defmodule SobelowTest.Config.CSRFTest do
     assert Config.get_pipelines(router)
            |> Enum.any?(&Config.vuln_pipeline?(&1, :csrf))
   end
+
+  test "honors sobelow_skip on vulnerable pipelines" do
+    Application.put_env(:sobelow, :skip, true)
+    on_exit(fn -> Application.delete_env(:sobelow, :skip) end)
+
+    router = "./test/fixtures/csrf/skipped_router.ex"
+
+    vulnerable =
+      Config.get_unskipped_pipelines(router, Sobelow.Config.CSRF)
+      |> Enum.filter(&Config.vuln_pipeline?(&1, :csrf))
+
+    # :browser is skipped, :other is not
+    assert [{:pipeline, _, [:other, _]}] = vulnerable
+  end
 end

--- a/test/config/headers_test.exs
+++ b/test/config/headers_test.exs
@@ -22,4 +22,33 @@ defmodule SobelowTest.Config.HeadersTest do
     assert Config.get_pipelines(router)
            |> Enum.any?(&Config.vuln_pipeline?(&1, :headers))
   end
+
+  test "honors sobelow_skip on vulnerable pipelines" do
+    Application.put_env(:sobelow, :skip, true)
+    on_exit(fn -> Application.delete_env(:sobelow, :skip) end)
+
+    router = "./test/fixtures/headers/skipped_router.ex"
+
+    vulnerable =
+      Config.get_unskipped_pipelines(router, Sobelow.Config.Headers)
+      |> Enum.filter(&Config.vuln_pipeline?(&1, :headers))
+
+    # :browser is skipped, :other is not
+    assert [{:pipeline, _, [:other, _]}] = vulnerable
+  end
+
+  test "does not honor sobelow_skip when skip flag is disabled" do
+    Application.put_env(:sobelow, :skip, false)
+    on_exit(fn -> Application.delete_env(:sobelow, :skip) end)
+
+    router = "./test/fixtures/headers/skipped_router.ex"
+
+    vulnerable =
+      Config.get_unskipped_pipelines(router, Sobelow.Config.Headers)
+      |> Enum.filter(&Config.vuln_pipeline?(&1, :headers))
+
+    assert length(vulnerable) == 2
+    assert Enum.find(vulnerable, &match?({:pipeline, _, [:browser, _]}, &1))
+    assert Enum.find(vulnerable, &match?({:pipeline, _, [:other, _]}, &1))
+  end
 end

--- a/test/fixtures/csp/skipped_router.ex
+++ b/test/fixtures/csp/skipped_router.ex
@@ -1,0 +1,15 @@
+# Router has put_secure_browser_headers without CSP, but skipped
+defmodule SkippedCSPRouter do
+  @moduledoc false
+
+  # sobelow_skip ["Config.CSP"]
+  pipeline :browser do
+    plug(:accepts, ["html"])
+    plug(:put_secure_browser_headers)
+  end
+
+  pipeline :other do
+    plug(:accepts, ["html"])
+    plug(:put_secure_browser_headers)
+  end
+end

--- a/test/fixtures/csrf/skipped_router.ex
+++ b/test/fixtures/csrf/skipped_router.ex
@@ -1,0 +1,17 @@
+# Router is missing plug :protect_from_forgery, but skipped
+defmodule SkippedCSRFRouter do
+  @moduledoc false
+
+  # sobelow_skip ["Config.CSRF"]
+  pipeline :browser do
+    plug(:accepts, ["html"])
+    plug(:fetch_session)
+    plug(:fetch_flash)
+  end
+
+  pipeline :other do
+    plug(:accepts, ["html"])
+    plug(:fetch_session)
+    plug(:fetch_flash)
+  end
+end

--- a/test/fixtures/headers/skipped_router.ex
+++ b/test/fixtures/headers/skipped_router.ex
@@ -1,0 +1,15 @@
+# Router is missing plug :put_secure_browser_headers, but skipped
+defmodule SkippedHeadersRouter do
+  @moduledoc false
+
+  # sobelow_skip ["Config.Headers"]
+  pipeline :browser do
+    plug(:accepts, ["html"])
+    plug(:protect_from_forgery)
+  end
+
+  pipeline :other do
+    plug(:accepts, ["html"])
+    plug(:protect_from_forgery)
+  end
+end


### PR DESCRIPTION
On a team with a big codebase, maintaining skip rules in the `router.ex` gets to be quite tedious, because adding or removing any lines from the router requires regenerating the `.sobelow-skips` file. The team getting comfortable doing this is a behavioral problem, because once you've reviewed enough bulk-rewrites of a dozen lines in that file, you become complacent and stop scrutinizing each one ("does this have any _meaningful_ difference from the last one?").

This PR attempts to address that complacency by supporting inline disable comments in the router, just above the relevant `pipeline` lines, so that we can localize the skip rules to the actual code they're linked to, rather than needing to maintain a separate, machine-generated skip file.

(The diff looks large, but 2/3 of it is docs and tests. 😅)