### PR TITLE
feat: Support inline `# sobelow_skip` comments on Phoenix router pipelines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@
       `conn.${atom_to_string(field)}`.
     * `.sobelow-conf` keys are now genuinely sorted alphabetically.
   * Enhancements
+    * `# sobelow_skip` comments now work on Phoenix router pipelines, not just
+      functions. This makes `Config.CSRF`, `Config.Headers`, and `Config.CSP`
+      suppressible per pipeline instead of only via `--mark-skip-all`, so an API
+      pipeline that legitimately has no `:protect_from_forgery` can be annotated
+      in place. Listing the parent `Config` module skips every Config check on
+      that pipeline. As with function-level skips, this only takes effect under
+      `--skip`.
     * `--private` now skips the version check entirely rather than still writing
       the cache file. It makes no network requests and touches no files outside
       the scanned project.
@@ -46,6 +53,11 @@
       coverage for every bug above. Line coverage went from 29% to 67%.
     * Added coverage for CLI option parsing, `.sobelow-conf` precedence, `--exit`
       and `--threshold` mapping, and the `json`/`sarif`/`quiet`/`txt` renderers.
+    * Added end-to-end coverage for pipeline-level `# sobelow_skip` comments, and
+      unit coverage for how skips associate with pipelines in the AST.
+    * `Sobelow.ScanCase.temp_fixture_file/3` now restores a committed fixture's
+      original contents instead of deleting the file, so a test can vary a
+      checked-in fixture without destroying it.
   * Misc
     * Replaced the deprecated `:preferred_cli_env` project key with `def cli`.
     * Bumped `credo` to `~> 1.7.19`; 1.7.12 crashed on Elixir 1.20.

--- a/README.md
+++ b/README.md
@@ -200,6 +200,10 @@ pipeline :browser do
 end
 ```
 
+Listing the parent `Config` module skips every Config check on
+that pipeline, in the same way that `-i Config` ignores the
+whole group.
+
 When integrating Sobelow into a new project, there can be a
 large number of false positives. To mark all printed findings
 as false positives, run sobelow with the `--mark-skip-all` flag.

--- a/README.md
+++ b/README.md
@@ -189,6 +189,17 @@ def vuln_func(...) do
 end
 ```
 
+The same syntax works for Phoenix router pipelines, which is
+useful for configuration findings such as `Config.CSRF` and
+`Config.Headers`:
+
+```elixir
+# sobelow_skip ["Config.Headers"]
+pipeline :browser do
+  ...
+end
+```
+
 When integrating Sobelow into a new project, there can be a
 large number of false positives. To mark all printed findings
 as false positives, run sobelow with the `--mark-skip-all` flag.
@@ -198,10 +209,9 @@ Sobelow with the `--skip` flag.
 
     $ mix sobelow --skip
 
-While `# sobelow_skip` comments can only mark function-level
-findings (and so cannot be used to skip configuration issues),
-the `--mark-skip-all` flag can be used to skip any finding
-type.
+While `# sobelow_skip` comments mark function- and pipeline-level
+findings, the `--mark-skip-all` flag can be used to skip any
+finding type.
 
 ## Modules
 Findings categories are broken up into modules. These modules

--- a/lib/mix/tasks/sobelow.ex
+++ b/lib/mix/tasks/sobelow.ex
@@ -22,7 +22,7 @@ defmodule Mix.Tasks.Sobelow do
   * `--strict` - Exit when bad syntax is encountered
   * `--mark-skip-all` - Mark all printed findings as skippable
   * `--clear-skip` - Clear configuration added by `--mark-skip-all`
-  * `--skip` - Skip functions flagged with `#sobelow_skip` or tagged with `--mark-skip-all`
+  * `--skip` - Skip functions/Phoenix pipelines flagged with `#sobelow_skip` or tagged with `--mark-skip-all`
   * `--router` - Specify router location
   * `--exit` - Return non-zero exit status
   * `--threshold` - Only return findings at or above a given confidence level

--- a/lib/sobelow/config.ex
+++ b/lib/sobelow/config.ex
@@ -111,8 +111,9 @@ defmodule Sobelow.Config do
   end
 
   def get_unskipped_pipelines(filepath, check_mod) do
-    get_pipelines_with_skips(filepath)
-    |> Enum.reject(&skipped_pipeline?(&1, check_mod))
+    filepath
+    |> get_pipelines_with_skips()
+    |> Enum.reject(fn {_pipeline, skips} -> skipped?(skips, check_mod) end)
     |> Enum.map(fn {pipeline, _skips} -> pipeline end)
   end
 
@@ -122,15 +123,16 @@ defmodule Sobelow.Config do
     |> Parse.get_pipelines_with_skips()
   end
 
-  defp skipped_pipeline?({_pipeline, skips}, check_mod) when is_list(skips) do
+  # A pipeline skip matches either the specific check (`Config.CSRF`) or the
+  # parent module (`Config`), which suppresses every Config check on that
+  # pipeline. This mirrors `-i Config`, which drops the whole Config group.
+  defp skipped?(skips, check_mod) do
     Sobelow.get_env(:skip) &&
       Enum.any?(skips, fn skip ->
         mod = Sobelow.get_mod(skip)
         mod == check_mod || mod == __MODULE__
       end)
   end
-
-  defp skipped_pipeline?(_, _), do: false
 
   def get_plug_list(block) do
     case block do

--- a/lib/sobelow/config.ex
+++ b/lib/sobelow/config.ex
@@ -105,10 +105,32 @@ defmodule Sobelow.Config do
   # Config utils
 
   def get_pipelines(filepath) do
-    ast = Parse.ast(filepath)
-    {_, acc} = Macro.prewalk(ast, [], &Parse.get_funs_of_type(&1, &2, :pipeline))
-    acc
+    filepath
+    |> get_pipelines_with_skips()
+    |> Enum.map(fn {pipeline, _skips} -> pipeline end)
   end
+
+  def get_unskipped_pipelines(filepath, check_mod) do
+    get_pipelines_with_skips(filepath)
+    |> Enum.reject(&skipped_pipeline?(&1, check_mod))
+    |> Enum.map(fn {pipeline, _skips} -> pipeline end)
+  end
+
+  defp get_pipelines_with_skips(filepath) do
+    filepath
+    |> Parse.ast()
+    |> Parse.get_pipelines_with_skips()
+  end
+
+  defp skipped_pipeline?({_pipeline, skips}, check_mod) when is_list(skips) do
+    Sobelow.get_env(:skip) &&
+      Enum.any?(skips, fn skip ->
+        mod = Sobelow.get_mod(skip)
+        mod == check_mod || mod == __MODULE__
+      end)
+  end
+
+  defp skipped_pipeline?(_, _), do: false
 
   def get_plug_list(block) do
     case block do

--- a/lib/sobelow/config/csp.ex
+++ b/lib/sobelow/config/csp.ex
@@ -26,6 +26,14 @@ defmodule Sobelow.Config.CSP do
   Content-Security-Policy checks can be ignored with the following command:
 
       $ mix sobelow -i Config.CSP
+
+  False positives can be ignored at the pipeline level by
+  adding a `# sobelow_skip` comment:
+
+      # sobelow_skip ["Config.CSP"]
+      pipeline :browser do
+        ...
+      end
   """
   alias Sobelow.Config
 
@@ -38,7 +46,7 @@ defmodule Sobelow.Config.CSP do
     meta_file = Parse.ast(router) |> Parse.get_meta_funs()
     finding = Finding.init(@finding_type, Utils.normalize_path(router))
 
-    Config.get_pipelines(router)
+    Config.get_unskipped_pipelines(router, __MODULE__)
     |> Enum.map(&check_vuln_pipeline(&1, meta_file))
     |> Enum.each(&maybe_add_finding(&1, finding))
   end

--- a/lib/sobelow/config/csp.ex
+++ b/lib/sobelow/config/csp.ex
@@ -34,6 +34,9 @@ defmodule Sobelow.Config.CSP do
       pipeline :browser do
         ...
       end
+
+  This requires the `--skip` flag. Listing the parent `Config`
+  module instead skips every Config check on that pipeline.
   """
   alias Sobelow.Config
 

--- a/lib/sobelow/config/csrf.ex
+++ b/lib/sobelow/config/csrf.ex
@@ -16,6 +16,14 @@ defmodule Sobelow.Config.CSRF do
   CSRF checks can be ignored with the following command:
 
       $ mix sobelow -i Config.CSRF
+
+  False positives can be ignored at the pipeline level by
+  adding a `# sobelow_skip` comment:
+
+      # sobelow_skip ["Config.CSRF"]
+      pipeline :api do
+        ...
+      end
   """
   alias Sobelow.Config
 
@@ -27,7 +35,7 @@ defmodule Sobelow.Config.CSRF do
   def run(router) do
     finding = Finding.init(@finding_type, Utils.normalize_path(router))
 
-    Config.get_pipelines(router)
+    Config.get_unskipped_pipelines(router, __MODULE__)
     |> Stream.filter(&vuln_pipeline?/1)
     |> Enum.each(&add_finding(&1, finding))
   end

--- a/lib/sobelow/config/csrf.ex
+++ b/lib/sobelow/config/csrf.ex
@@ -24,6 +24,9 @@ defmodule Sobelow.Config.CSRF do
       pipeline :api do
         ...
       end
+
+  This requires the `--skip` flag. Listing the parent `Config`
+  module instead skips every Config check on that pipeline.
   """
   alias Sobelow.Config
 

--- a/lib/sobelow/config/headers.ex
+++ b/lib/sobelow/config/headers.ex
@@ -22,6 +22,9 @@ defmodule Sobelow.Config.Headers do
       pipeline :browser do
         ...
       end
+
+  This requires the `--skip` flag. Listing the parent `Config`
+  module instead skips every Config check on that pipeline.
   """
   alias Sobelow.Config
 

--- a/lib/sobelow/config/headers.ex
+++ b/lib/sobelow/config/headers.ex
@@ -14,6 +14,14 @@ defmodule Sobelow.Config.Headers do
   command:
 
       $ mix sobelow -i Config.Headers
+
+  False positives can be ignored at the pipeline level by
+  adding a `# sobelow_skip` comment:
+
+      # sobelow_skip ["Config.Headers"]
+      pipeline :browser do
+        ...
+      end
   """
   alias Sobelow.Config
 
@@ -25,7 +33,7 @@ defmodule Sobelow.Config.Headers do
   def run(router) do
     finding = Finding.init(@finding_type, Utils.normalize_path(router))
 
-    Config.get_pipelines(router)
+    Config.get_unskipped_pipelines(router, __MODULE__)
     |> Stream.filter(&vuln_pipeline?/1)
     |> Enum.each(&add_finding(&1, finding))
   end

--- a/lib/sobelow/parse.ex
+++ b/lib/sobelow/parse.ex
@@ -102,39 +102,68 @@ defmodule Sobelow.Parse do
   def get_meta_funs(ast) do
     init_acc = %{def_funs: [], use_funs: [], module_attrs: []}
     {_, acc} = Macro.prewalk(ast, init_acc, &get_meta_funs(&1, &2))
-    acc
+
+    # A `@sobelow_skip` that annotates a pipeline has already been consumed by
+    # `get_pipelines_with_skips/1`. Leaving it in `def_funs` would let
+    # `Sobelow.combine_skips/2` bind it to the next function in the file as well.
+    consumed = pipeline_skip_attrs(ast)
+    Map.update!(acc, :def_funs, &Enum.reject(&1, fn fun -> MapSet.member?(consumed, fun) end))
   end
 
   @doc false
-  # Collects `pipeline` macros with any immediately preceding `@sobelow_skip`
-  # attributes (converted from `# sobelow_skip` comments when `--skip` is set).
-  # Phoenix router pipelines are macros, not `def`/`defp`, so the normal
-  # function-level skip association does not apply to them.
+  # Every `pipeline` macro in the AST, paired with the skips from any
+  # immediately preceding `@sobelow_skip` attributes (rewritten from
+  # `# sobelow_skip` comments by `read_file/1` when `--skip` is set).
+  #
+  # Phoenix router pipelines are macros, not `def`/`defp`, so the function-level
+  # skip association in `Sobelow.combine_skips/2` never reaches them.
+  #
+  # Collection and association are deliberately separate walks: `get_funs_of_type/2`
+  # finds pipelines wherever they appear, so a pipeline nested in something other
+  # than a plain block (say, inside an `if`) is still scanned — just without skips.
   def get_pipelines_with_skips(ast) do
-    {_, acc} = Macro.prewalk(ast, [], &collect_pipelines_with_skips/2)
-    acc
+    skips = Map.new(skip_associations(ast), fn {pipeline, skips, _attrs} -> {pipeline, skips} end)
+
+    ast
+    |> get_funs_of_type(:pipeline)
+    |> Enum.reverse()
+    |> Enum.map(&{&1, Map.get(skips, &1, [])})
   end
 
-  defp collect_pipelines_with_skips({:__block__, meta, stmts}, acc) when is_list(stmts) do
-    pipelines = associate_skips_with_pipelines(stmts)
-    {{:__block__, meta, stmts}, acc ++ pipelines}
+  defp pipeline_skip_attrs(ast) do
+    ast
+    |> skip_associations()
+    |> Enum.flat_map(fn {_pipeline, _skips, attrs} -> attrs end)
+    |> MapSet.new()
   end
 
-  # A module whose only expression is a pipeline has no surrounding `__block__`.
-  defp collect_pipelines_with_skips(
-         {:defmodule, meta, [alias_ast, [do: {:pipeline, _, _} = pipeline]]},
-         acc
-       ) do
-    {{:defmodule, meta, [alias_ast, [do: pipeline]]}, acc ++ [{pipeline, []}]}
+  # `read_file/1` only rewrites skip comments into attributes under `--skip`, so
+  # without it there is nothing to associate and the walk can be skipped entirely.
+  defp skip_associations(ast) do
+    if Sobelow.get_env(:skip) do
+      {_, acc} = Macro.prewalk(ast, [], &collect_skip_associations/2)
+      acc
+    else
+      []
+    end
   end
 
-  defp collect_pipelines_with_skips(ast, acc), do: {ast, acc}
+  defp collect_skip_associations({:__block__, _, stmts} = ast, acc) when is_list(stmts) do
+    {ast, acc ++ associate_skips_with_pipelines(stmts)}
+  end
 
+  defp collect_skip_associations(ast, acc), do: {ast, acc}
+
+  # `@sobelow_skip` attributes bind to the next `pipeline` in the same block. Any
+  # other statement in between clears them, mirroring the way a function-level
+  # skip has to sit immediately above its `def`. A pipeline that carries a skip
+  # always has at least two statements in its block, so it always has a
+  # `__block__` to be found in.
   defp associate_skips_with_pipelines(statements) do
-    {pipelines, _pending_skips} =
+    {associations, _pending} =
       Enum.reduce(statements, {[], []}, fn
-        {:@, _, [{:sobelow_skip, _, [skips]}]}, {acc, pending} when is_list(skips) ->
-          {acc, pending ++ skips}
+        {:@, _, [{:sobelow_skip, _, [skips]}]} = attr, {acc, pending} when is_list(skips) ->
+          {acc, pending ++ [{attr, skips}]}
 
         {:pipeline, _, _} = pipeline, {acc, pending} ->
           {[{pipeline, pending} | acc], []}
@@ -143,7 +172,9 @@ defmodule Sobelow.Parse do
           {acc, []}
       end)
 
-    Enum.reverse(pipelines)
+    Enum.map(associations, fn {pipeline, pending} ->
+      {pipeline, Enum.flat_map(pending, &elem(&1, 1)), Enum.map(pending, &elem(&1, 0))}
+    end)
   end
 
   def get_meta_funs({:@, _, [{:sobelow_skip, _, _}]} = ast, acc) do

--- a/lib/sobelow/parse.ex
+++ b/lib/sobelow/parse.ex
@@ -105,6 +105,47 @@ defmodule Sobelow.Parse do
     acc
   end
 
+  @doc false
+  # Collects `pipeline` macros with any immediately preceding `@sobelow_skip`
+  # attributes (converted from `# sobelow_skip` comments when `--skip` is set).
+  # Phoenix router pipelines are macros, not `def`/`defp`, so the normal
+  # function-level skip association does not apply to them.
+  def get_pipelines_with_skips(ast) do
+    {_, acc} = Macro.prewalk(ast, [], &collect_pipelines_with_skips/2)
+    acc
+  end
+
+  defp collect_pipelines_with_skips({:__block__, meta, stmts}, acc) when is_list(stmts) do
+    pipelines = associate_skips_with_pipelines(stmts)
+    {{:__block__, meta, stmts}, acc ++ pipelines}
+  end
+
+  # A module whose only expression is a pipeline has no surrounding `__block__`.
+  defp collect_pipelines_with_skips(
+         {:defmodule, meta, [alias_ast, [do: {:pipeline, _, _} = pipeline]]},
+         acc
+       ) do
+    {{:defmodule, meta, [alias_ast, [do: pipeline]]}, acc ++ [{pipeline, []}]}
+  end
+
+  defp collect_pipelines_with_skips(ast, acc), do: {ast, acc}
+
+  defp associate_skips_with_pipelines(statements) do
+    {pipelines, _pending_skips} =
+      Enum.reduce(statements, {[], []}, fn
+        {:@, _, [{:sobelow_skip, _, [skips]}]}, {acc, pending} when is_list(skips) ->
+          {acc, pending ++ skips}
+
+        {:pipeline, _, _} = pipeline, {acc, pending} ->
+          {[{pipeline, pending} | acc], []}
+
+        _, {acc, _pending} ->
+          {acc, []}
+      end)
+
+    Enum.reverse(pipelines)
+  end
+
   def get_meta_funs({:@, _, [{:sobelow_skip, _, _}]} = ast, acc) do
     if Sobelow.get_env(:skip) do
       {ast, Map.update!(acc, :def_funs, &[ast | &1])}

--- a/test/config/csp_test.exs
+++ b/test/config/csp_test.exs
@@ -51,6 +51,25 @@ defmodule SobelowTest.Config.CSPTest do
            |> Enum.any?(&vuln?/1)
   end
 
+  test "honors sobelow_skip on vulnerable pipelines" do
+    Application.put_env(:sobelow, :skip, true)
+    on_exit(fn -> Application.delete_env(:sobelow, :skip) end)
+
+    router = "./test/fixtures/csp/skipped_router.ex"
+
+    meta_file =
+      Parse.ast(router)
+      |> Parse.get_meta_funs()
+
+    vulnerable =
+      Config.get_unskipped_pipelines(router, CSP)
+      |> Enum.map(&CSP.check_vuln_pipeline(&1, meta_file))
+      |> Enum.filter(&vuln?/1)
+
+    # :browser is skipped, :other is not
+    assert [{true, _, _, {:pipeline, _, [:other, _]}}] = vulnerable
+  end
+
   defp vuln?({true, _, _, _}), do: true
   defp vuln?(_), do: false
 end

--- a/test/config/csrf_test.exs
+++ b/test/config/csrf_test.exs
@@ -29,4 +29,18 @@ defmodule SobelowTest.Config.CSRFTest do
     assert Config.get_pipelines(router)
            |> Enum.any?(&Config.vuln_pipeline?(&1, :csrf))
   end
+
+  test "honors sobelow_skip on vulnerable pipelines" do
+    Application.put_env(:sobelow, :skip, true)
+    on_exit(fn -> Application.delete_env(:sobelow, :skip) end)
+
+    router = "./test/fixtures/csrf/skipped_router.ex"
+
+    vulnerable =
+      Config.get_unskipped_pipelines(router, Sobelow.Config.CSRF)
+      |> Enum.filter(&Config.vuln_pipeline?(&1, :csrf))
+
+    # :browser is skipped, :other is not
+    assert [{:pipeline, _, [:other, _]}] = vulnerable
+  end
 end

--- a/test/config/headers_test.exs
+++ b/test/config/headers_test.exs
@@ -22,4 +22,33 @@ defmodule SobelowTest.Config.HeadersTest do
     assert Config.get_pipelines(router)
            |> Enum.any?(&Config.vuln_pipeline?(&1, :headers))
   end
+
+  test "honors sobelow_skip on vulnerable pipelines" do
+    Application.put_env(:sobelow, :skip, true)
+    on_exit(fn -> Application.delete_env(:sobelow, :skip) end)
+
+    router = "./test/fixtures/headers/skipped_router.ex"
+
+    vulnerable =
+      Config.get_unskipped_pipelines(router, Sobelow.Config.Headers)
+      |> Enum.filter(&Config.vuln_pipeline?(&1, :headers))
+
+    # :browser is skipped, :other is not
+    assert [{:pipeline, _, [:other, _]}] = vulnerable
+  end
+
+  test "does not honor sobelow_skip when skip flag is disabled" do
+    Application.put_env(:sobelow, :skip, false)
+    on_exit(fn -> Application.delete_env(:sobelow, :skip) end)
+
+    router = "./test/fixtures/headers/skipped_router.ex"
+
+    vulnerable =
+      Config.get_unskipped_pipelines(router, Sobelow.Config.Headers)
+      |> Enum.filter(&Config.vuln_pipeline?(&1, :headers))
+
+    assert length(vulnerable) == 2
+    assert Enum.find(vulnerable, &match?({:pipeline, _, [:browser, _]}, &1))
+    assert Enum.find(vulnerable, &match?({:pipeline, _, [:other, _]}, &1))
+  end
 end

--- a/test/e2e/pipeline_skip_test.exs
+++ b/test/e2e/pipeline_skip_test.exs
@@ -1,0 +1,145 @@
+defmodule Sobelow.PipelineSkipTest do
+  @moduledoc """
+  End-to-end coverage for `# sobelow_skip` comments on Phoenix router pipelines.
+
+  The unit tests in `test/config` exercise `Config.get_unskipped_pipelines/2`
+  directly. These drive the whole `Sobelow.run/0` pipeline, which is what
+  actually rewrites the comment into a `@sobelow_skip` attribute and honours it.
+  """
+  use Sobelow.ScanCase
+
+  @router_path "lib/basic_web/router.ex"
+
+  defp router(skip_comment) do
+    """
+    defmodule BasicWeb.Router do
+      use BasicWeb, :router
+
+      #{skip_comment}
+      pipeline :browser do
+        plug(:accepts, ["html"])
+        plug(:fetch_session)
+      end
+
+      scope "/", BasicWeb do
+        pipe_through(:browser)
+
+        get("/", PageController, :index)
+      end
+    end
+    """
+  end
+
+  test "the unmodified router reports CSRF and Headers under --skip" do
+    mods = finding_modules(scan("basic", skip: true))
+
+    assert "Config.CSRF" in mods
+    assert "Config.Headers" in mods
+  end
+
+  test "a pipeline skip comment suppresses only the listed checks" do
+    temp_fixture_file("basic", @router_path, router(~s(# sobelow_skip ["Config.CSRF"])))
+
+    mods = finding_modules(scan("basic", skip: true))
+
+    refute "Config.CSRF" in mods
+    assert "Config.Headers" in mods
+  end
+
+  test "a pipeline skip comment can list several checks" do
+    temp_fixture_file(
+      "basic",
+      @router_path,
+      router(~s(# sobelow_skip ["Config.CSRF", "Config.Headers"]))
+    )
+
+    mods = finding_modules(scan("basic", skip: true))
+
+    refute "Config.CSRF" in mods
+    refute "Config.Headers" in mods
+  end
+
+  test "the parent `Config` module suppresses every Config check on the pipeline" do
+    temp_fixture_file("basic", @router_path, router(~s(# sobelow_skip ["Config"])))
+
+    mods = finding_modules(scan("basic", skip: true))
+
+    refute "Config.CSRF" in mods
+    refute "Config.Headers" in mods
+  end
+
+  test "a pipeline skip comment is ignored without --skip" do
+    temp_fixture_file(
+      "basic",
+      @router_path,
+      router(~s(# sobelow_skip ["Config.CSRF", "Config.Headers"]))
+    )
+
+    mods = finding_modules(scan("basic", skip: false))
+
+    assert "Config.CSRF" in mods
+    assert "Config.Headers" in mods
+  end
+
+  test "an unrelated check listed on a pipeline does not suppress the pipeline" do
+    temp_fixture_file("basic", @router_path, router(~s(# sobelow_skip ["XSS.Raw"])))
+
+    mods = finding_modules(scan("basic", skip: true))
+
+    assert "Config.CSRF" in mods
+    assert "Config.Headers" in mods
+  end
+
+  test "a pipeline skip does not leak onto the next function in the router" do
+    router = """
+    defmodule BasicWeb.Router do
+      use BasicWeb, :router
+
+      # sobelow_skip ["Traversal.SendFile"]
+      pipeline :browser do
+        plug(:accepts, ["html"])
+        plug(:fetch_session)
+      end
+
+      def download(conn, %{"path" => path}) do
+        send_file(conn, 200, path)
+      end
+    end
+    """
+
+    temp_fixture_file("basic", @router_path, router)
+
+    assert router_finding?(scan("basic", skip: true), "Traversal.SendFile"),
+           "the skip belonged to the pipeline, so `download/2` must still be scanned"
+  end
+
+  test "a function-level skip in the router still works" do
+    router = """
+    defmodule BasicWeb.Router do
+      use BasicWeb, :router
+
+      pipeline :browser do
+        plug(:accepts, ["html"])
+        plug(:fetch_session)
+      end
+
+      # sobelow_skip ["Traversal.SendFile"]
+      def download(conn, %{"path" => path}) do
+        send_file(conn, 200, path)
+      end
+    end
+    """
+
+    temp_fixture_file("basic", @router_path, router)
+
+    refute router_finding?(scan("basic", skip: true), "Traversal.SendFile")
+  end
+
+  # The fixture app reports `Traversal.SendFile` in its controller too, so match
+  # on the router specifically.
+  defp router_finding?(report, module) do
+    report
+    |> findings_for(module)
+    |> Enum.any?(&String.ends_with?(Map.fetch!(&1, "file"), "router.ex"))
+  end
+end

--- a/test/fixtures/csp/skipped_router.ex
+++ b/test/fixtures/csp/skipped_router.ex
@@ -1,0 +1,15 @@
+# Router has put_secure_browser_headers without CSP, but skipped
+defmodule SkippedCSPRouter do
+  @moduledoc false
+
+  # sobelow_skip ["Config.CSP"]
+  pipeline :browser do
+    plug(:accepts, ["html"])
+    plug(:put_secure_browser_headers)
+  end
+
+  pipeline :other do
+    plug(:accepts, ["html"])
+    plug(:put_secure_browser_headers)
+  end
+end

--- a/test/fixtures/csrf/skipped_router.ex
+++ b/test/fixtures/csrf/skipped_router.ex
@@ -1,0 +1,17 @@
+# Router is missing plug :protect_from_forgery, but skipped
+defmodule SkippedCSRFRouter do
+  @moduledoc false
+
+  # sobelow_skip ["Config.CSRF"]
+  pipeline :browser do
+    plug(:accepts, ["html"])
+    plug(:fetch_session)
+    plug(:fetch_flash)
+  end
+
+  pipeline :other do
+    plug(:accepts, ["html"])
+    plug(:fetch_session)
+    plug(:fetch_flash)
+  end
+end

--- a/test/fixtures/headers/skipped_router.ex
+++ b/test/fixtures/headers/skipped_router.ex
@@ -1,0 +1,15 @@
+# Router is missing plug :put_secure_browser_headers, but skipped
+defmodule SkippedHeadersRouter do
+  @moduledoc false
+
+  # sobelow_skip ["Config.Headers"]
+  pipeline :browser do
+    plug(:accepts, ["html"])
+    plug(:protect_from_forgery)
+  end
+
+  pipeline :other do
+    plug(:accepts, ["html"])
+    plug(:protect_from_forgery)
+  end
+end

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -29,4 +29,124 @@ defmodule SobelowTest.ParserTest do
 
     assert capture_io(run_test) =~ "Code Execution in `Code.eval_string` - Medium Confidence"
   end
+
+  describe "get_pipelines_with_skips/1" do
+    setup do
+      Application.put_env(:sobelow, :skip, true)
+      on_exit(fn -> Application.put_env(:sobelow, :skip, false) end)
+    end
+
+    defp pipeline_names(source) do
+      {:ok, ast} = Code.string_to_quoted(source)
+
+      ast
+      |> Sobelow.Parse.get_pipelines_with_skips()
+      |> Enum.map(fn {{:pipeline, _, [name | _]}, skips} -> {name, skips} end)
+    end
+
+    test "collects pipelines in source order" do
+      source = """
+      defmodule R do
+        use W, :router
+
+        pipeline :browser do
+          plug(:accepts, ["html"])
+        end
+
+        pipeline :api do
+          plug(:accepts, ["json"])
+        end
+      end
+      """
+
+      assert [browser: [], api: []] = pipeline_names(source)
+    end
+
+    test "collects a pipeline that is a module's only expression" do
+      source = """
+      defmodule R do
+        pipeline :browser do
+          plug(:accepts, ["html"])
+        end
+      end
+      """
+
+      assert [browser: []] = pipeline_names(source)
+    end
+
+    # A pipeline is scanned wherever it appears. Associating skips only works for
+    # pipelines in a plain block, but a nested one must still be reported rather
+    # than silently dropped.
+    test "collects a pipeline nested outside a plain block" do
+      source = """
+      defmodule R do
+        use W, :router
+
+        if Mix.env() == :dev do
+          pipeline :dev_only do
+            plug(:accepts, ["html"])
+          end
+        end
+
+        pipeline :browser do
+          plug(:accepts, ["html"])
+        end
+      end
+      """
+
+      names = pipeline_names(source)
+
+      assert {:dev_only, []} in names
+      assert {:browser, []} in names
+    end
+
+    test "associates a skip with the pipeline that follows it" do
+      source = """
+      defmodule R do
+        use W, :router
+
+        @sobelow_skip ["Config.CSRF"]
+        pipeline :browser do
+          plug(:accepts, ["html"])
+        end
+
+        pipeline :api do
+          plug(:accepts, ["json"])
+        end
+      end
+      """
+
+      assert [browser: ["Config.CSRF"], api: []] = pipeline_names(source)
+    end
+
+    test "does not associate a skip separated from the pipeline by another statement" do
+      source = """
+      defmodule R do
+        @sobelow_skip ["Config.CSRF"]
+        use W, :router
+
+        pipeline :browser do
+          plug(:accepts, ["html"])
+        end
+      end
+      """
+
+      assert [browser: []] = pipeline_names(source)
+    end
+
+    test "returns no skips when the skip flag is disabled" do
+      Application.put_env(:sobelow, :skip, false)
+
+      source = """
+      defmodule R do
+        @sobelow_skip ["Config.CSRF"]
+        pipeline :browser do
+          plug(:accepts, ["html"])
+        end
+      end
+      """
+
+      assert [browser: []] = pipeline_names(source)
+    end
+  end
 end

--- a/test/support/scan_case.ex
+++ b/test/support/scan_case.ex
@@ -131,13 +131,24 @@ defmodule Sobelow.ScanCase do
 
   Used for fixtures that must not be committed in a broken state, because
   `mix format --check-formatted` covers `test/**`.
+
+  If the path is an existing, committed fixture, its original contents are
+  restored afterwards rather than deleted, so a test can vary a checked-in
+  fixture without destroying it.
   """
   def temp_fixture_file(fixture, relative_path, contents) do
     path = Path.join(fixture_path(fixture), relative_path)
+    original = File.read(path)
 
     File.mkdir_p!(Path.dirname(path))
     File.write!(path, contents)
-    ExUnit.Callbacks.on_exit(fn -> File.rm_rf!(path) end)
+
+    ExUnit.Callbacks.on_exit(fn ->
+      case original do
+        {:ok, original} -> File.write!(path, original)
+        {:error, _} -> File.rm_rf!(path)
+      end
+    end)
 
     path
   end

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -46,9 +46,9 @@ Use `--threshold low|medium|high` to filter the report by confidence.
 
 There are two mechanisms and they are not interchangeable.
 
-**`# sobelow_skip` comments** mark a *specific function*. They only work for
-function-level findings — they cannot suppress configuration findings, which are not
-attached to a function.
+**`# sobelow_skip` comments** mark a *specific function* or a *specific Phoenix
+router pipeline*. The comment must sit immediately above the `def` or `pipeline`
+it applies to.
 
 ```elixir
 # sobelow_skip ["Traversal.SendFile", "XSS.Raw"]
@@ -56,6 +56,23 @@ def download(conn, params) do
   ...
 end
 ```
+
+On a pipeline they suppress the router configuration checks — `Config.CSRF`,
+`Config.Headers`, and `Config.CSP`:
+
+```elixir
+# sobelow_skip ["Config.CSRF"]
+pipeline :api do
+  ...
+end
+```
+
+Listing the parent `Config` module suppresses every Config check on that
+pipeline, the same way `-i Config` ignores the whole group.
+
+They still cannot suppress configuration findings that are not attached to a
+function or a pipeline — `Config.Secrets` or `Config.HTTPS`, for instance, which
+come from `config/*.exs`. Use `--mark-skip-all` for those.
 
 **`--mark-skip-all`** writes every currently-reported finding to a `.sobelow-skips`
 file, and works for *all* finding types including configuration ones. Use it when


### PR DESCRIPTION
Supersedes #33 by @s3cur3, whose original commit is preserved here with authorship intact. The feature and its design are entirely their work; this branch rebases it onto `main` and addresses review follow-ups.

> [!IMPORTANT]
> **Please rebase-merge this PR, not squash-merge.** Squashing collapses both commits into one single-authored commit and would strip @s3cur3's authorship of the feature. Rebase merge preserves it, so the commit lands on `main` authored by them and counts toward their contributions.

Also supersedes #28, which addressed the `Config.CSRF` slice of the same problem. That one can be closed too.

## What this adds

`# sobelow_skip` comments previously only worked on functions, so router configuration findings could only be suppressed with the blunt `--mark-skip-all`. They now work on Phoenix router pipelines:

```elixir
# sobelow_skip ["Config.CSRF"]
pipeline :api do
  ...
end
```

This covers `Config.CSRF`, `Config.Headers`, and `Config.CSP`. Listing the parent `Config` module skips every Config check on that pipeline, mirroring `-i Config`. As with function-level skips, it only takes effect under `--skip`.

## Follow-up commit

The second commit addresses findings from reviewing the original PR against current `main`:

- **Never drop a pipeline.** Collection and skip-association are now separate walks. The original implementation collected pipelines exclusively from `__block__` statements, so a pipeline nested in anything else (e.g. `if Mix.env() == :dev do`) was silently never scanned — a false negative in a security scanner. `get_funs_of_type/2` now finds every pipeline wherever it appears; the block walk only attaches skips.

- **Stop a pipeline's skip from binding to the next function.** `read_file/1` rewrites the comment into an `@sobelow_skip` attribute, which `get_meta_funs/1` collected into `def_funs`, letting `combine_skips/2` apply it to the following `def` as well. Attributes consumed by a pipeline are now excluded. Function-level skips are unaffected, and there's a test for each direction.

- **Documented the parent-`Config` behaviour** in the README, moduledocs, and `usage-rules.md`. It already worked but was undocumented and untested.

- **Removed an unreachable `skipped_pipeline?/2` clause.**

- **Updated `usage-rules.md`**, which still stated that skip comments cannot suppress configuration findings, and added a `CHANGELOG` entry. Both files landed on `main` after #33 was opened.

## Testing

171 tests pass, up from 157. `mix format --check-formatted`, `mix compile --warnings-as-errors`, and `mix credo --all --strict` are all clean.

The original tests called `Config.get_unskipped_pipelines/2` directly, so nothing exercised the `mix sobelow --skip` path a user actually runs. Added 8 end-to-end tests driving `Sobelow.run/0` through `Sobelow.ScanCase` — that path is what rewrites the comment into an attribute and honours it — plus 6 unit tests for how skips associate with pipelines in the AST.

Also fixed a sharp edge in `ScanCase.temp_fixture_file/3`, which cleaned up with `File.rm_rf!` and so *deleted* committed fixtures rather than restoring them. It now restores original contents, which the new tests depend on.

## Reviewer note

Both behavioural fixes touch `Sobelow.Parse`, which every checker shares — not just the three Config ones. The suite is green, but the `get_meta_funs/1` rejection runs on every file scanned and is worth a second look.