### PR TITLE
perf: only re-walk files that actually carry a `sobelow_skip` attribute

### DIFF
--- a/lib/sobelow/parse.ex
+++ b/lib/sobelow/parse.ex
@@ -106,9 +106,21 @@ defmodule Sobelow.Parse do
     # A `@sobelow_skip` that annotates a pipeline has already been consumed by
     # `get_pipelines_with_skips/1`. Leaving it in `def_funs` would let
     # `Sobelow.combine_skips/2` bind it to the next function in the file as well.
-    consumed = pipeline_skip_attrs(ast)
-    Map.update!(acc, :def_funs, &Enum.reject(&1, fn fun -> MapSet.member?(consumed, fun) end))
+    #
+    # Only a file that actually carries a skip attribute can have one rejected,
+    # and virtually none do, so the second walk is gated on the first one having
+    # found something. Under `--skip` this is the difference between paying for
+    # an extra full traversal of every scanned file and paying for none.
+    if Enum.any?(acc.def_funs, &skip_attr?/1) do
+      consumed = pipeline_skip_attrs(ast)
+      Map.update!(acc, :def_funs, &Enum.reject(&1, fn fun -> MapSet.member?(consumed, fun) end))
+    else
+      acc
+    end
   end
+
+  defp skip_attr?({:@, _, [{:sobelow_skip, _, _}]}), do: true
+  defp skip_attr?(_), do: false
 
   @doc false
   # Every `pipeline` macro in the AST, paired with the skips from any

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -149,4 +149,98 @@ defmodule SobelowTest.ParserTest do
       assert [browser: []] = pipeline_names(source)
     end
   end
+
+  # `get_meta_funs/1` drops the `@sobelow_skip` attributes that a pipeline has
+  # already consumed, so `Sobelow.combine_skips/2` cannot also bind them to the
+  # next function. A correctly placed function-level skip can never be consumed:
+  # the statement directly after the attribute is either a `pipeline` or a `def`,
+  # and only the former consumes it.
+  describe "get_meta_funs/1 and pipeline skips" do
+    setup do
+      Application.put_env(:sobelow, :skip, true)
+      on_exit(fn -> Application.put_env(:sobelow, :skip, false) end)
+    end
+
+    defp def_fun_summary(source) do
+      {:ok, ast} = Code.string_to_quoted(source)
+
+      ast
+      |> Sobelow.Parse.get_meta_funs()
+      |> Map.fetch!(:def_funs)
+      |> Enum.map(fn
+        {:@, _, [{:sobelow_skip, _, [skips]}]} -> {:skip_attr, skips}
+        {kind, _, [{name, _, _} | _]} -> {kind, name}
+      end)
+    end
+
+    test "a skip consumed by a pipeline is not left for the next function" do
+      source = """
+      defmodule R do
+        use W, :router
+
+        @sobelow_skip ["Traversal.SendFile"]
+        pipeline :browser do
+          plug(:accepts, ["html"])
+        end
+
+        def download(conn, params) do
+          send_file(conn, 200, params["path"])
+        end
+      end
+      """
+
+      assert [def: :download] = def_fun_summary(source)
+    end
+
+    test "a function-level skip is preserved in a router that also skips a pipeline" do
+      source = """
+      defmodule R do
+        use W, :router
+
+        @sobelow_skip ["Config.CSRF"]
+        pipeline :browser do
+          plug(:accepts, ["html"])
+        end
+
+        @sobelow_skip ["Traversal.SendFile"]
+        def download(conn, params) do
+          send_file(conn, 200, params["path"])
+        end
+      end
+      """
+
+      assert [def: :download, skip_attr: ["Traversal.SendFile"]] = def_fun_summary(source)
+    end
+
+    test "a plain function-level skip is untouched" do
+      source = """
+      defmodule M do
+        @sobelow_skip ["Traversal.SendFile"]
+        def download(conn, params) do
+          send_file(conn, 200, params["path"])
+        end
+      end
+      """
+
+      assert [def: :download, skip_attr: ["Traversal.SendFile"]] = def_fun_summary(source)
+    end
+
+    test "a `pipeline` call in a non-router module still consumes an adjacent skip" do
+      # Not a Phoenix router, but the association is purely syntactic. The skip
+      # binds to the `pipeline` call, so it must not reach `handle/1`. This is
+      # the safe direction: a lost skip surfaces a finding rather than hiding one.
+      source = """
+      defmodule M do
+        @sobelow_skip ["Traversal.SendFile"]
+        pipeline :something
+
+        def handle(conn, params) do
+          send_file(conn, 200, params["path"])
+        end
+      end
+      """
+
+      assert [def: :handle] = def_fun_summary(source)
+    end
+  end
 end


### PR DESCRIPTION
Follow-up to the reviewer note on #35: both behavioural fixes there landed in `Sobelow.Parse`, which every checker shares rather than only the three Config ones. This is the result of auditing that.

## What the audit found

The `get_meta_funs/1` rejection — which stops a pipeline's `@sobelow_skip` from also binding to the next function — required a second full `Macro.prewalk` of the AST, and it ran on **every scanned file**, not just routers.

Under `--skip`, the mode `usage-rules.md` recommends for CI, that doubled the cost of `get_meta_funs/1`:

```
skip:false (extra walk short-circuited): 2.1 ms per full pass
skip:true  (extra walk runs)           : 4.2 ms per full pass
overhead under --skip: 95.0%
```

(308 files: this repo's `lib/` plus `deps/credo/lib/`.) Virtually none of those files contain a skip attribute, so nearly all of that work was wasted.

## The fix

The first walk already collects skip attributes into `def_funs`, so the second can be gated on it having found one. After:

```
skip:false: 2.2 ms per full pass
skip:true : 2.0 ms per full pass
```

This is **behaviour-preserving by construction** — a file with no skip attribute cannot have one rejected, so the gated branch is a no-op exactly when it is skipped. Verified empirically as well: scans of all three fixture apps with `--skip` both on and off produce byte-identical output before and after (34 findings across 6 scans).

## On the correctness of the rejection itself

The invariant worth recording, now covered by tests: **a correctly placed function-level skip can never be consumed by a pipeline.** A skip attribute is consumed only when a `pipeline` statement follows it immediately in the same block, and a function-level skip must sit immediately above its `def`. The statement after the attribute is one or the other, never both.

The remaining edge case is a non-router module with a `pipeline`-shaped call directly after a skip comment. The association is purely syntactic, so the skip binds to that call and does not reach the following function. That fails in the safe direction for a security tool — it surfaces a finding rather than hiding one — and it requires the comment to be misplaced to begin with. There's a test pinning this behaviour so it can't change silently.

## Testing

175 tests pass, up from 171. `mix format --check-formatted`, `mix compile --warnings-as-errors`, and `mix credo --all --strict` are clean.

Four new regression tests cover the association invariant: a consumed skip not reaching the next function, a function-level skip surviving in a router that also skips a pipeline, a plain function-level skip being untouched, and the non-router `pipeline` call edge case.