### PR TITLE
fix: tolerate empty `.sobelow-conf` files instead of failing the scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@
     * A malformed `.sobelow-conf` now produces an actionable message instead of a
       raw `MatchError` stacktrace. This mattered more since v0.14.1 began reading
       the file automatically.
+    * An empty, whitespace-only, or comment-only `.sobelow-conf` is now read as
+      no options rather than aborting the scan. Such a file parses to an empty
+      block instead of a keyword list, so it originally crashed with a
+      `FunctionClauseError` and then, once that was fixed, exited 1 with a
+      configuration error. Since the file is read automatically, a stray
+      `touch .sobelow-conf` or a truncated write was enough to break every scan
+      in a project. Contents that cannot be interpreted are still an error.
     * `--save-config` now stores `ignore_files` relative to the project root.
       Absolute paths were previously baked into `.sobelow-conf`, breaking the
       committed file on every other machine and in CI.

--- a/lib/mix/tasks/sobelow.ex
+++ b/lib/mix/tasks/sobelow.ex
@@ -217,11 +217,23 @@ defmodule Mix.Tasks.Sobelow do
   def read_config_file(conf_file) do
     with {:ok, contents} <- File.read(conf_file),
          {:ok, opts} <- Code.string_to_quoted(contents),
-         true <- Keyword.keyword?(opts) do
+         {:ok, opts} <- validate_config(opts) do
       {:ok, opts}
     else
       _ -> {:error, config_file_error(conf_file)}
     end
+  end
+
+  # An empty (or comment-only) config file is a benign state — `touch
+  # .sobelow-conf`, a truncated write — and parses to an empty block rather than
+  # to a keyword list. Since v0.14.1 reads the file automatically, treating that
+  # as fatal would break scans over a file that asks for nothing. Contents we
+  # cannot make sense of are still an error, so a scan never silently runs with
+  # configuration the user believed was applied.
+  defp validate_config({:__block__, _, []}), do: {:ok, []}
+
+  defp validate_config(opts) do
+    if Keyword.keyword?(opts), do: {:ok, opts}, else: :error
   end
 
   defp load_config_file(conf_file) do

--- a/test/mix_task_test.exs
+++ b/test/mix_task_test.exs
@@ -149,6 +149,21 @@ defmodule SobelowTest.MixTaskTest do
       assert env.exit_on == false
       assert env.ignored == []
     end
+
+    # The original symptom was the task aborting outright, so cover the whole
+    # option-parsing path and not just `read_config_file/1`. An empty file must
+    # leave the defaults intact rather than halt.
+    @tag :tmp_dir
+    test "an empty file leaves the defaults intact", %{tmp_dir: tmp_dir} do
+      File.write!(Path.join(tmp_dir, ".sobelow-conf"), "")
+
+      env = parse(["--root", tmp_dir])
+
+      assert env.format == "txt"
+      assert env.threshold == :low
+      assert env.exit_on == false
+      assert env.ignored == []
+    end
   end
 
   describe "read_config_file/1" do
@@ -181,6 +196,46 @@ defmodule SobelowTest.MixTaskTest do
     test "reports an error for a missing file", %{tmp_dir: tmp_dir} do
       assert {:error, _message} =
                Mix.Tasks.Sobelow.read_config_file(Path.join(tmp_dir, "nope"))
+    end
+
+    # A file that asks for nothing is not a misconfiguration. `.sobelow-conf` is
+    # read automatically, so treating these as fatal broke scans over a file that
+    # a `touch` or a truncated write was enough to produce.
+    test "treats an empty file as no options", %{tmp_dir: tmp_dir} do
+      path = Path.join(tmp_dir, ".sobelow-conf")
+      File.write!(path, "")
+
+      assert Mix.Tasks.Sobelow.read_config_file(path) == {:ok, []}
+    end
+
+    test "treats a whitespace-only file as no options", %{tmp_dir: tmp_dir} do
+      path = Path.join(tmp_dir, ".sobelow-conf")
+      File.write!(path, "\n\n   \n")
+
+      assert Mix.Tasks.Sobelow.read_config_file(path) == {:ok, []}
+    end
+
+    test "treats a comment-only file as no options", %{tmp_dir: tmp_dir} do
+      path = Path.join(tmp_dir, ".sobelow-conf")
+      File.write!(path, "# no options yet\n")
+
+      assert Mix.Tasks.Sobelow.read_config_file(path) == {:ok, []}
+    end
+
+    # Empty is tolerated, but anything we cannot interpret must still fail loudly
+    # rather than let a scan run with settings the user believed were applied.
+    test "still rejects a parseable term that is merely falsy", %{tmp_dir: tmp_dir} do
+      path = Path.join(tmp_dir, ".sobelow-conf")
+      File.write!(path, "nil")
+
+      assert {:error, _message} = Mix.Tasks.Sobelow.read_config_file(path)
+    end
+
+    test "still rejects a non-keyword list", %{tmp_dir: tmp_dir} do
+      path = Path.join(tmp_dir, ".sobelow-conf")
+      File.write!(path, ~s(["XSS.Raw"]))
+
+      assert {:error, _message} = Mix.Tasks.Sobelow.read_config_file(path)
     end
   end
 end


### PR DESCRIPTION
Supersedes #22 by @stuartjohnpage. **Their commit is cherry-picked here with authorship intact** — please rebase-merge rather than squash, so it lands on `main` attributed to them.

## Background

#34 fixed the `FunctionClauseError` @stuartjohnpage reported, and independently arrived at the same `Keyword.keyword?/1` guard they proposed. But it resolved it in the opposite direction: an unusable config file now prints an error and exits 1.

That is right for genuinely malformed contents. It is wrong for an *empty* file, which is the case #22 was actually named after. An empty file parses to `{:__block__, [line: 1], []}` rather than to a keyword list, so it took the error path:

```
completely empty: :error
whitespace only:  :error
comment only:     :error
```

Since `config` defaults to `true` (`sobelow.ex:124`) and v0.14.1 began reading `.sobelow-conf` automatically, a stray `touch .sobelow-conf` or a truncated write was enough to hard-fail **every scan in a project** with exit 1. So the crash was fixed but the underlying report was not: the file was still fatal.

## What this changes

An empty, whitespace-only, or comment-only file is read as no options. Anything that cannot be interpreted as a keyword list is still an error, so a scan never silently runs with configuration the user believed was applied.

| contents | before | after |
|---|---|---|
| empty / whitespace / comment-only | `:error` → exit 1 | `{:ok, []}` |
| valid keyword list | `{:ok, opts}` | `{:ok, opts}` |
| unparseable | `:error` | `:error` |
| map, bare list, `nil` | `:error` | `:error` |

## On the cherry-pick

The original patched the inline config merge in `run/1`, which #34 extracted into `read_config_file/1`, so it did not apply cleanly. I resolved the conflict by implementing the same intent in the new structure and noted the adaptation in the commit message. The contribution — identifying that an empty config file should not break scans — is theirs.

## Testing

181 tests pass, up from 175. `mix format --check-formatted`, `mix compile --warnings-as-errors`, and `mix credo --all --strict` are clean.

`read_config_file/1` previously had tests for unparseable contents, non-keyword terms, and a missing file — but not for the empty file the report was about. Added coverage for all three empty variants, plus the cases that must still fail. One test drives the full option-parsing path rather than `read_config_file/1` alone, since the original symptom was the task aborting rather than a bad return value.

I confirmed each new test fails without the fix.