### PR TITLE
fix: Only match unqualified `query`/`query!` where Ecto is in scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,14 @@
       and `# sobelow_skip [ "XSS.Raw" ]` were all ignored — silently, and
       indistinguishably from a skip that had simply not applied. Spacing around
       the marker, inside the list, and around commas is now irrelevant.
+    * `SQL.Query` no longer reports a project's own `query/1` as SQL injection.
+      An unqualified `query`/`query!` call was matched regardless of what it
+      referred to, so every call to a local function that happened to carry one
+      of those very ordinary names produced a finding. The unqualified form is
+      now only considered in a file that has `import Ecto.Adapters.SQL` or
+      `use Ecto.Repo` — the two ways the bare name can actually reach Ecto.
+      Qualified calls, such as `Repo.query/1` and `Ecto.Adapters.SQL.query/3`,
+      are unaffected.
   * Enhancements
     * Added `--no-router`, for scanning a project that has no Phoenix router.
       Sobelow warned that it could not find one and offered no way to silence it,

--- a/lib/sobelow.ex
+++ b/lib/sobelow.ex
@@ -438,6 +438,7 @@ defmodule Sobelow do
     meta_funs = Parse.get_meta_funs(ast)
     def_funs = meta_funs.def_funs
     use_funs = meta_funs.use_funs
+    import_funs = meta_funs.import_funs
 
     %{
       filename: Utils.normalize_path(filename),
@@ -445,7 +446,12 @@ defmodule Sobelow do
       def_funs: def_funs,
       controller?: Utils.controller?(use_funs),
       router?: Utils.router?(use_funs),
-      is_endpoint?: Utils.endpoint?(use_funs)
+      is_endpoint?: Utils.endpoint?(use_funs),
+      # An unqualified `query/3` only means Ecto's if the file imported it, and an
+      # unqualified `query/1` only means a repo's if the file is one. Without that
+      # evidence a bare `query(...)` is somebody's own function.
+      imports_ecto_sql?: Utils.imports?(import_funs, [:Ecto, :Adapters, :SQL]),
+      ecto_repo?: Utils.uses?(use_funs, [:Ecto, :Repo])
     }
   end
 

--- a/lib/sobelow/parse.ex
+++ b/lib/sobelow/parse.ex
@@ -151,7 +151,7 @@ defmodule Sobelow.Parse do
   end
 
   def get_meta_funs(ast) do
-    init_acc = %{def_funs: [], use_funs: [], module_attrs: []}
+    init_acc = %{def_funs: [], use_funs: [], import_funs: [], module_attrs: []}
     {_, acc} = Macro.prewalk(ast, init_acc, &get_meta_funs(&1, &2))
 
     # A `@sobelow_skip` that annotates a pipeline has already been consumed by
@@ -262,6 +262,10 @@ defmodule Sobelow.Parse do
 
   def get_meta_funs({:use, _, _} = ast, acc) do
     {ast, Map.update!(acc, :use_funs, &[ast | &1])}
+  end
+
+  def get_meta_funs({:import, _, _} = ast, acc) do
+    {ast, Map.update!(acc, :import_funs, &[ast | &1])}
   end
 
   def get_meta_funs({:@, _, [attr | _]} = ast, acc) do

--- a/lib/sobelow/sql/query.ex
+++ b/lib/sobelow/sql/query.ex
@@ -8,6 +8,12 @@ defmodule Sobelow.SQL.Query do
 
   Ensure that the query is parameterized and not user-controlled.
 
+  Calls are matched when they are qualified — `Repo.query(sql)` or
+  `Ecto.Adapters.SQL.query(Repo, sql, [])`. A bare `query(...)` is only treated
+  as Ecto's in a file that has `import Ecto.Adapters.SQL` or `use Ecto.Repo`,
+  since otherwise the name almost always belongs to a function of the project's
+  own.
+
   SQLi Query checks can be ignored with the following command:
 
       $ mix sobelow -i SQL.Query
@@ -23,23 +29,30 @@ defmodule Sobelow.SQL.Query do
 
     Enum.each(@query_funcs, fn query_func ->
       Finding.init(@finding_type, meta_file.filename, confidence)
-      |> Finding.multi_from_def(fun, parse_sql_def(fun, query_func))
+      |> Finding.multi_from_def(fun, parse_sql_def(fun, query_func, meta_file.imports_ecto_sql?))
       |> Enum.each(&Print.add_finding(&1))
     end)
 
     Enum.each(@query_funcs, fn query_func ->
       Finding.init(@finding_type, meta_file.filename, confidence)
-      |> Finding.multi_from_def(fun, parse_repo_query_def(fun, query_func))
+      |> Finding.multi_from_def(fun, parse_repo_query_def(fun, query_func, meta_file.ecto_repo?))
       |> Enum.each(&Print.add_finding(&1))
     end)
   end
 
   ## query(repo, sql, params \\ [], opts \\ [])
-  def parse_sql_def(fun, type) do
-    Parse.get_fun_vars_and_meta(fun, 1, type, :SQL)
+  def parse_sql_def(fun, type, unqualified? \\ false) do
+    Parse.get_fun_vars_and_meta(fun, 1, type, module(:SQL, unqualified?))
   end
 
-  def parse_repo_query_def(fun, type) do
-    Parse.get_fun_vars_and_meta(fun, 0, type, :Repo)
+  def parse_repo_query_def(fun, type, unqualified? \\ false) do
+    Parse.get_fun_vars_and_meta(fun, 0, type, module(:Repo, unqualified?))
   end
+
+  # `query`/`query!` are common names. Matching them unqualified flags every
+  # local function that happens to be called one, so it is only done for a file
+  # that imported `Ecto.Adapters.SQL` or is itself an `Ecto.Repo` — the two ways
+  # the bare name can reach Ecto. Everywhere else the call must be qualified.
+  defp module(module, true), do: module
+  defp module(module, false), do: {:required, module}
 end

--- a/lib/sobelow/utils.ex
+++ b/lib/sobelow/utils.ex
@@ -19,6 +19,31 @@ defmodule Sobelow.Utils do
   def has_use_type?([_ | t], type), do: has_use_type?(t, type)
   def has_use_type?(_, _), do: false
 
+  @doc """
+  Whether `uses` contains a `use` of `module`, given as alias segments.
+
+      uses?(use_funs, [:Ecto, :Repo])
+  """
+  def uses?(uses, module), do: references?(uses, :use, module)
+
+  @doc """
+  Whether `imports` contains an `import` of `module`, given as alias segments.
+  """
+  def imports?(imports, module), do: references?(imports, :import, module)
+
+  defp references?(nodes, kind, module) do
+    Enum.any?(nodes, fn
+      {^kind, _, [{:__aliases__, _, aliases} | _]} -> alias_of?(aliases, module)
+      _ -> false
+    end)
+  end
+
+  # The module may have been aliased first, so only the tail of its name appears:
+  # `alias Ecto.Adapters.SQL; import SQL` gives `[:SQL]`. Matching on a suffix
+  # accepts that without accepting an unrelated `Some.Other.SQL`.
+  defp alias_of?([], _module), do: false
+  defp alias_of?(aliases, module), do: Enum.take(module, -length(aliases)) == aliases
+
   def normalize_path(filename) do
     filename
     |> Path.expand("")

--- a/test/e2e/regression_test.exs
+++ b/test/e2e/regression_test.exs
@@ -182,6 +182,76 @@ defmodule SobelowTest.E2E.RegressionTest do
     end
   end
 
+  # https://github.com/sobelow/sobelow/issues/30 — a project with its own
+  # `query/1` got a SQL injection finding on every call to it.
+  describe "SQL.Query on unqualified calls" do
+    defp sql_findings_in(report, path) do
+      report
+      |> findings_for("SQL.Query")
+      |> Enum.filter(&String.ends_with?(&1["file"], path))
+    end
+
+    test "a local function named query/1 is not reported" do
+      temp_fixture_file("basic", "lib/basic/local_query.ex", """
+      defmodule Basic.LocalQuery do
+        def sobelow_test(arg), do: query(arg)
+        def query(arg), do: 42
+      end
+      """)
+
+      report = scan("basic")
+
+      assert sql_findings_in(report, "lib/basic/local_query.ex") == []
+      # The rest of the scan is untouched: the fixture's own qualified
+      # `Ecto.Adapters.SQL.query/3` is still found.
+      assert length(findings_for(report, "SQL.Query")) == 1
+    end
+
+    test "an unqualified query/3 is reported when the file imported Ecto.Adapters.SQL" do
+      temp_fixture_file("basic", "lib/basic/imported_query.ex", """
+      defmodule Basic.ImportedQuery do
+        import Ecto.Adapters.SQL
+
+        def run(%{"sql" => sql}), do: query(Repo, sql, [])
+      end
+      """)
+
+      report = scan("basic")
+
+      assert [finding] = sql_findings_in(report, "lib/basic/imported_query.ex")
+      assert finding["variable"] == "sql"
+    end
+
+    test "an unqualified query/1 is reported inside an Ecto.Repo" do
+      temp_fixture_file("basic", "lib/basic/repo.ex", """
+      defmodule Basic.Repo do
+        use Ecto.Repo, otp_app: :basic, adapter: Ecto.Adapters.Postgres
+
+        def run(%{"sql" => sql}), do: query(sql)
+      end
+      """)
+
+      report = scan("basic")
+
+      assert [finding] = sql_findings_in(report, "lib/basic/repo.ex")
+      assert finding["variable"] == "sql"
+    end
+
+    test "an unrelated module ending in SQL does not re-enable unqualified matching" do
+      temp_fixture_file("basic", "lib/basic/unrelated.ex", """
+      defmodule Basic.Unrelated do
+        import Some.Other.SQL
+
+        def run(%{"sql" => sql}), do: query(sql)
+      end
+      """)
+
+      report = scan("basic")
+
+      assert sql_findings_in(report, "lib/basic/unrelated.ex") == []
+    end
+  end
+
   describe "Parse.normalize_finding/1" do
     test "renders a dot-access variable rather than leaking the interpolation source" do
       dot_access = {:., [line: 1], [{:conn, [line: 1], nil}, :body_params]}

--- a/test/sql/query_test.exs
+++ b/test/sql/query_test.exs
@@ -60,4 +60,68 @@ defmodule SobelowTest.SQL.QueryTest do
       refute Query.parse_repo_query_def(ast, query_func) |> vuln?
     end)
   end
+
+  # `query` and `query!` are ordinary function names. Matching them unqualified
+  # flags every local function that happens to be called one, so the unqualified
+  # form is only considered for a file that imported `Ecto.Adapters.SQL` or is
+  # itself an `Ecto.Repo`. See https://github.com/sobelow/sobelow/issues/30.
+  describe "unqualified calls" do
+    test "are not matched by default" do
+      Enum.each(@query_funcs, fn query_func ->
+        func = """
+        def caller(%{"sql" => sql}) do
+          #{query_func}(sql)
+        end
+        """
+
+        {_, ast} = Code.string_to_quoted(func)
+
+        refute Query.parse_repo_query_def(ast, query_func) |> vuln?
+        refute Query.parse_sql_def(ast, query_func) |> vuln?
+      end)
+    end
+
+    test "are matched when the file is an `Ecto.Repo`" do
+      Enum.each(@query_funcs, fn query_func ->
+        func = """
+        def caller(%{"sql" => sql}) do
+          #{query_func}(sql)
+        end
+        """
+
+        {_, ast} = Code.string_to_quoted(func)
+
+        assert Query.parse_repo_query_def(ast, query_func, true) |> vuln?
+      end)
+    end
+
+    test "are matched when the file imported `Ecto.Adapters.SQL`" do
+      Enum.each(@query_funcs, fn query_func ->
+        func = """
+        def caller(%{"sql" => sql}) do
+          #{query_func}(Repo, sql, [])
+        end
+        """
+
+        {_, ast} = Code.string_to_quoted(func)
+
+        assert Query.parse_sql_def(ast, query_func, true) |> vuln?
+      end)
+    end
+
+    test "do not affect qualified calls, which are matched either way" do
+      Enum.each(@query_funcs, fn query_func ->
+        func = """
+        def caller(%{"sql" => sql}) do
+          Repo.#{query_func}(sql)
+        end
+        """
+
+        {_, ast} = Code.string_to_quoted(func)
+
+        assert Query.parse_repo_query_def(ast, query_func) |> vuln?
+        assert Query.parse_repo_query_def(ast, query_func, true) |> vuln?
+      end)
+    end
+  end
 end

--- a/test/utils_test.exs
+++ b/test/utils_test.exs
@@ -18,4 +18,53 @@ defmodule SobelowTest.UtilsTest do
     assert Sobelow.Utils.get_app_name("./test/fixtures/utils/mix_with_releases_test_app.exs") ==
              "test"
   end
+
+  describe "Utils.imports?/2 and Utils.uses?/2" do
+    defp meta_funs(source) do
+      {:ok, ast} = Code.string_to_quoted(source)
+      Sobelow.Parse.get_meta_funs(ast)
+    end
+
+    test "match a plain import" do
+      %{import_funs: imports} = meta_funs("import Ecto.Adapters.SQL")
+
+      assert Sobelow.Utils.imports?(imports, [:Ecto, :Adapters, :SQL])
+    end
+
+    test "match an import with options" do
+      %{import_funs: imports} = meta_funs("import Ecto.Adapters.SQL, only: [query: 3]")
+
+      assert Sobelow.Utils.imports?(imports, [:Ecto, :Adapters, :SQL])
+    end
+
+    test "match an import of a module that was aliased first" do
+      %{import_funs: imports} = meta_funs("alias Ecto.Adapters.SQL\nimport SQL")
+
+      assert Sobelow.Utils.imports?(imports, [:Ecto, :Adapters, :SQL])
+    end
+
+    test "do not match a different module with the same last segment" do
+      %{import_funs: imports} = meta_funs("import Some.Other.SQL")
+
+      refute Sobelow.Utils.imports?(imports, [:Ecto, :Adapters, :SQL])
+    end
+
+    test "do not match a longer name that merely contains the target" do
+      %{import_funs: imports} = meta_funs("import My.Ecto.Adapters.SQL")
+
+      refute Sobelow.Utils.imports?(imports, [:Ecto, :Adapters, :SQL])
+    end
+
+    test "uses?/2 matches a `use` with options" do
+      %{use_funs: uses} = meta_funs("use Ecto.Repo, otp_app: :my_app")
+
+      assert Sobelow.Utils.uses?(uses, [:Ecto, :Repo])
+      refute Sobelow.Utils.uses?(uses, [:Ecto, :Adapters, :SQL])
+    end
+
+    test "an empty list matches nothing" do
+      refute Sobelow.Utils.imports?([], [:Ecto, :Adapters, :SQL])
+      refute Sobelow.Utils.uses?([], [:Ecto, :Repo])
+    end
+  end
 end


### PR DESCRIPTION
Closes #30.

### The problem

`SQL.Query` matched a bare `query(...)` call regardless of what it referred to. @Cohen-Carlisle's reproduction:

```elixir
defmodule SobelowTest do
  def sobelow_test(arg), do: query(arg)
  def query(arg), do: 42
end
```

```
SQL.Query: SQL injection - Low Confidence
File: lib/sobelow_test.ex
Line: 2
Function: sobelow_test:2
Variable: arg
```

They had 245 hits across 122 files and worked around it by renaming their functions.

`Parse.get_fun_vars_and_meta/4` is given a module to look for. When that module is an atom rather than a list, it matches module-qualified calls *and* falls back to any bare call of the same name. For `Conn`/`Controller`/`HTML` that fallback is load-bearing, because `use Phoenix.Controller` genuinely imports `send_resp`, `html`, and friends. For `SQL` and `Repo` it is not: `query` and `query!` are ordinary names, and nothing puts them in scope by default.

### The fix

An unqualified `query`/`query!` can only reach Ecto two ways:

- `import Ecto.Adapters.SQL`, which gives `query/3`
- being inside a module that `use`s `Ecto.Repo`, which defines `query/1`

The unqualified form is now only considered when the file shows one of those. Everywhere else the call must be qualified — which is what `SQL.Stream` has always required via `{:required, :SQL}`.

Qualified calls are untouched: `Repo.query/1`, `Ecto.Adapters.SQL.query/3`, `SQL.query!/3`, and their piped forms all still report.

Supporting changes:

- `Parse.get_meta_funs/1` collects `import` nodes alongside the `use` nodes it already gathered.
- `Utils.imports?/2` and `Utils.uses?/2` test for a module by its alias segments. Both accept an aliased reference — `alias Ecto.Adapters.SQL; import SQL` — by matching a **suffix** of the module's name. A suffix match is what makes `Some.Other.SQL` and `My.Ecto.Adapters.SQL` *not* count.

### Verified against a scratch project

| file | code | before | after |
|---|---|---|---|
| `not_ecto.ex` | `def a(%{"sql" => sql}), do: query(sql)` with a local `def query/1` | ⚠️ reported | ✅ clean |
| `unrelated_import.ex` | `import Some.Other.SQL` + bare `query(sql)` | ⚠️ reported | ✅ clean |
| `qualified.ex` | `Ecto.Adapters.SQL.query`, `SQL.query!`, `MyApp.Repo.query`, `sql \|> Repo.query()` | reported | ✅ still reported (4) |
| `imported.ex` | `import Ecto.Adapters.SQL` + bare `query`/`query!` | reported | ✅ still reported (2) |
| `aliased_import.ex` | `alias Ecto.Adapters.SQL; import SQL` + bare `query` | reported | ✅ still reported |
| `some_repo.ex` | `use Ecto.Repo` + bare `query(sql)` and `sql \|> query!()` | reported | ✅ still reported (2) |

### Tests

15 new tests, 211 → 226. Each guard was checked in both directions:

- reverting `{:required, module}` back to `module` fails the four tests that assert an unqualified call is *not* matched
- hard-coding `imports_ecto_sql?` and `ecto_repo?` to `false` fails the two tests that assert it *is*, so the import/`use` detection is genuinely load-bearing rather than incidentally passing

Full gate green: `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --all --strict` (no issues), `mix test` (226 passed).

### Known limitation

Detection is per file, not per module. A bare `query` in a file that elsewhere imports Ecto is still matched. That is the pre-existing behaviour rather than a regression, and one module per file is the norm; scoping to the enclosing `defmodule` would mean threading module context through `def_funs`, which also carries the skip association. Worth doing if it ever bites someone, not worth it pre-emptively.
