### PR TITLE
fix: Stop discarding `# sobelow_skip` comments over whitespace, and warn when one cannot be read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@
     * Fixed a string-interpolation typo that rendered dot-access variables as
       `conn.${atom_to_string(field)}`.
     * `.sobelow-conf` keys are now genuinely sorted alphabetically.
+    * `# sobelow_skip` comments are no longer thrown away over whitespace. The
+      pattern demanded exactly one space after the `#` and exactly one before
+      the list, so `# sobelow_skip["XSS.Raw"]`, `#  sobelow_skip ["XSS.Raw"]`,
+      and `# sobelow_skip [ "XSS.Raw" ]` were all ignored — silently, and
+      indistinguishably from a skip that had simply not applied. Spacing around
+      the marker, inside the list, and around commas is now irrelevant.
   * Enhancements
     * Added `--no-router`, for scanning a project that has no Phoenix router.
       Sobelow warned that it could not find one and offered no way to silence it,
@@ -57,6 +63,11 @@
       in place. Listing the parent `Config` module skips every Config check on
       that pipeline. As with function-level skips, this only takes effect under
       `--skip`.
+    * A `# sobelow_skip` comment that cannot be read now warns on stderr, naming
+      the file and line, instead of being dropped without a word. Single quotes
+      and a list broken across several comment lines are still not accepted, but
+      they now say so rather than leaving you to wonder why the finding came
+      back.
     * `--private` now skips the version check entirely rather than still writing
       the cache file. It makes no network requests and touches no files outside
       the scanned project.

--- a/lib/sobelow.ex
+++ b/lib/sobelow.ex
@@ -432,7 +432,9 @@ defmodule Sobelow do
   end
 
   defp get_file_meta(filename) do
-    ast = Parse.ast(filename)
+    # The one place every file in the project is read exactly once, so the place
+    # to report a `# sobelow_skip` comment we could not make sense of.
+    ast = Parse.ast_with_skip_warnings(filename)
     meta_funs = Parse.get_meta_funs(ast)
     def_funs = meta_funs.def_funs
     use_funs = meta_funs.use_funs

--- a/lib/sobelow/parse.ex
+++ b/lib/sobelow/parse.ex
@@ -38,7 +38,28 @@ defmodule Sobelow.Parse do
   ]
 
   def ast(filepath) do
-    case Code.string_to_quoted(read_file(filepath), columns: true, file: filepath) do
+    filepath
+    |> read_file()
+    |> parse(filepath)
+  end
+
+  @doc false
+  # `ast/1`, plus a warning for any `# sobelow_skip` comment that could not be
+  # read. An unrecognised comment is otherwise dropped in silence, which looks
+  # exactly like a skip that did not apply — the two are indistinguishable to
+  # someone whose comment simply has a stray space in it.
+  #
+  # Only for the one pass over every file in the project. `read_file/1` runs six
+  # times for a router, which is where pipeline skips live, so warning from
+  # there would repeat itself.
+  def ast_with_skip_warnings(filepath) do
+    content = read_file(filepath)
+    warn_unrecognised_skips(filepath, content)
+    parse(content, filepath)
+  end
+
+  defp parse(content, filepath) do
+    case Code.string_to_quoted(content, columns: true, file: filepath) do
       {:ok, ast} ->
         ast
 
@@ -80,18 +101,48 @@ defmodule Sobelow.Parse do
   def format_location(line) when is_integer(line), do: "#{line}:"
   def format_location(_), do: ""
 
+  # A `# sobelow_skip` comment, rewritten into a module attribute so it survives
+  # into the AST. Whitespace is deliberately loose: the spacing around the
+  # marker and inside the list carries no meaning, and being strict about it
+  # only produced comments that looked right and did nothing.
+  @skip_comment ~r/#\s*sobelow_skip\s*(\[\s*"[^"]+"(?:\s*,\s*"[^"]+")*\s*,?\s*\])/
+
+  # Anything that looks like an attempt at one. Requiring the bracket keeps
+  # prose that merely mentions `# sobelow_skip` from being flagged.
+  @skip_comment_attempt ~r/#\s*sobelow_skip\s*\[/
+
   defp read_file(filepath) do
     content = File.read!(filepath)
 
     if Sobelow.get_env(:skip) do
-      String.replace(
-        content,
-        ~r/#\s?sobelow_skip (\[(\"[^"]+\"(,|, )?)+\])/,
-        "@sobelow_skip \\g{1}"
-      )
+      String.replace(content, @skip_comment, "@sobelow_skip \\g{1}")
     else
       content
     end
+  end
+
+  # Runs against the rewritten content, so every comment that was understood has
+  # already become an attribute and whatever still reads as a skip comment is
+  # one we could not parse.
+  defp warn_unrecognised_skips(filepath, content) do
+    if Sobelow.get_env(:skip) do
+      content
+      |> String.split("\n")
+      |> Enum.with_index(1)
+      |> Enum.each(fn {line, line_no} ->
+        if Regex.match?(@skip_comment_attempt, line),
+          do: warn_unrecognised_skip(filepath, line_no)
+      end)
+    end
+  end
+
+  defp warn_unrecognised_skip(filepath, line_no) do
+    IO.puts(
+      :stderr,
+      "#{filepath}:#{line_no}: could not read this `# sobelow_skip` comment, so it was " <>
+        "ignored. Expected a list of double-quoted checks, " <>
+        ~s(for example: # sobelow_skip ["Config.CSRF"])
+    )
   end
 
   def get_meta_funs(filepath) when is_binary(filepath) do

--- a/test/e2e/pipeline_skip_test.exs
+++ b/test/e2e/pipeline_skip_test.exs
@@ -113,6 +113,59 @@ defmodule Sobelow.PipelineSkipTest do
            "the skip belonged to the pipeline, so `download/2` must still be scanned"
   end
 
+  # The reproduction from https://github.com/sobelow/sobelow/issues/27: a real
+  # router has more than one pipeline, and the skip has to land on the annotated
+  # one only.
+  test "a pipeline skip does not carry over to the next pipeline" do
+    router = """
+    defmodule BasicWeb.Router do
+      use BasicWeb, :router
+
+      # sobelow_skip ["Config.CSRF"]
+      pipeline :annotated do
+        plug(:accepts, ["html"])
+        plug(:fetch_session)
+      end
+
+      pipeline :unannotated do
+        plug(:accepts, ["html"])
+        plug(:fetch_session)
+      end
+    end
+    """
+
+    temp_fixture_file("basic", @router_path, router)
+
+    pipelines =
+      scan("basic", skip: true)
+      |> findings_for("Config.CSRF")
+      |> Enum.map(& &1["pipeline"])
+
+    assert pipelines == ["unannotated"]
+  end
+
+  # Comments and blank lines do not appear in the AST, so the rewritten
+  # `@sobelow_skip` attribute is still the statement immediately before the
+  # pipeline. Worth pinning: routers are often written this way.
+  test "a blank line between the comment and the pipeline does not break the association" do
+    router = """
+    defmodule BasicWeb.Router do
+      use BasicWeb, :router
+
+      # sobelow_skip ["Config.CSRF"]
+
+      pipeline :browser do
+        plug(:accepts, ["html"])
+        plug(:fetch_session)
+      end
+    end
+    """
+
+    temp_fixture_file("basic", @router_path, router)
+
+    refute "Config.CSRF" in finding_modules(scan("basic", skip: true))
+  end
+
   test "a function-level skip in the router still works" do
     router = """
     defmodule BasicWeb.Router do

--- a/test/e2e/pipeline_skip_test.exs
+++ b/test/e2e/pipeline_skip_test.exs
@@ -188,6 +188,121 @@ defmodule Sobelow.PipelineSkipTest do
     refute router_finding?(scan("basic", skip: true), "Traversal.SendFile")
   end
 
+  # The spacing around the marker and inside the list carries no meaning, so
+  # being strict about it only produced comments that looked right and did
+  # nothing. Each of these used to be ignored in silence.
+  describe "skip comment spacing" do
+    for {name, comment} <- [
+          {"no space after the hash", ~S(#sobelow_skip ["Config.CSRF"])},
+          {"several spaces after the hash", ~S(#   sobelow_skip ["Config.CSRF"])},
+          {"no space before the list", ~S(# sobelow_skip["Config.CSRF"])},
+          {"several spaces before the list", ~S(# sobelow_skip   ["Config.CSRF"])},
+          {"padding inside the list", ~S(# sobelow_skip [ "Config.CSRF" ])},
+          {"a space before the comma", ~S(# sobelow_skip ["Config.CSRF" , "Config.CSP"])},
+          {"no space after the comma", ~S(# sobelow_skip ["Config.CSRF","Config.CSP"])},
+          {"a trailing comma", ~S(# sobelow_skip ["Config.CSRF",])}
+        ] do
+      test "is tolerated: #{name}" do
+        temp_fixture_file("basic", @router_path, router(unquote(comment)))
+
+        refute "Config.CSRF" in finding_modules(scan("basic", skip: true))
+      end
+    end
+  end
+
+  describe "a skip comment that cannot be read" do
+    test "warns naming the file and line, rather than being ignored in silence" do
+      temp_fixture_file("basic", @router_path, router(~S(# sobelow_skip ['Config.CSRF'])))
+
+      {_stdout, stderr} = scan_io("basic", skip: true)
+
+      assert stderr =~ "#{@router_path}:4: could not read this `# sobelow_skip` comment"
+      assert stderr =~ ~S(# sobelow_skip ["Config.CSRF"])
+    end
+
+    test "still reports the finding it failed to suppress" do
+      temp_fixture_file("basic", @router_path, router(~S(# sobelow_skip ['Config.CSRF'])))
+
+      assert "Config.CSRF" in finding_modules(scan("basic", skip: true))
+    end
+
+    test "warns once, not once per read of the file" do
+      temp_fixture_file("basic", @router_path, router(~S(# sobelow_skip ['Config.CSRF'])))
+
+      {_stdout, stderr} = scan_io("basic", skip: true)
+
+      warnings =
+        stderr
+        |> String.split("\n")
+        |> Enum.count(&(&1 =~ "could not read this `# sobelow_skip` comment"))
+
+      assert warnings == 1
+    end
+
+    test "covers a list broken across several comment lines" do
+      router = """
+      defmodule BasicWeb.Router do
+        use BasicWeb, :router
+
+        # sobelow_skip [
+        #   "Config.CSRF"
+        # ]
+        pipeline :browser do
+          plug(:accepts, ["html"])
+          plug(:fetch_session)
+        end
+      end
+      """
+
+      temp_fixture_file("basic", @router_path, router)
+
+      {_stdout, stderr} = scan_io("basic", skip: true)
+
+      assert stderr =~ "#{@router_path}:4: could not read this `# sobelow_skip` comment"
+    end
+  end
+
+  describe "no warning is emitted" do
+    test "for a comment that was understood" do
+      temp_fixture_file("basic", @router_path, router(~S(# sobelow_skip ["Config.CSRF"])))
+
+      {_stdout, stderr} = scan_io("basic", skip: true)
+
+      refute stderr =~ "could not read"
+    end
+
+    # Without `--skip` nothing is rewritten, so every valid comment would look
+    # unrecognised.
+    test "without --skip, where skip comments are not read at all" do
+      temp_fixture_file("basic", @router_path, router(~S(# sobelow_skip ['Config.CSRF'])))
+
+      {_stdout, stderr} = scan_io("basic", skip: false)
+
+      refute stderr =~ "could not read"
+    end
+
+    # Requiring the bracket is what keeps prose out of it.
+    test "for prose that merely mentions the marker" do
+      router = """
+      defmodule BasicWeb.Router do
+        use BasicWeb, :router
+
+        # Suppress a check on a pipeline with a # sobelow_skip comment.
+        pipeline :browser do
+          plug(:accepts, ["html"])
+          plug(:fetch_session)
+        end
+      end
+      """
+
+      temp_fixture_file("basic", @router_path, router)
+
+      {_stdout, stderr} = scan_io("basic", skip: true)
+
+      refute stderr =~ "could not read"
+    end
+  end
+
   # The fixture app reports `Traversal.SendFile` in its controller too, so match
   # on the router specifically.
   defp router_finding?(report, module) do

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -70,6 +70,11 @@ end
 Listing the parent `Config` module suppresses every Config check on that
 pipeline, the same way `-i Config` ignores the whole group.
 
+Spacing does not matter, but the check names must be a list of double-quoted
+strings. A comment Sobelow cannot read is reported on stderr with its file and
+line rather than being ignored, so a skip that appears to do nothing is worth
+checking the warnings for.
+
 They still cannot suppress configuration findings that are not attached to a
 function or a pipeline — `Config.Secrets` or `Config.HTTPS`, for instance, which
 come from `config/*.exs`. Use `--mark-skip-all` for those.


### PR DESCRIPTION
Refs #27.

#35 made `# sobelow_skip` work on router pipelines, and I validated it against the reproduction in #27 — it does, on `main`. Two things came out of that validation.

## 1. Skip comments were being discarded over whitespace

The rewrite pattern demanded exactly one space after the `#` and exactly one before the list:

```elixir
~r/#\s?sobelow_skip (\[(\"[^"]+\"(,|, )?)+\])/
```

So all of these were ignored:

```elixir
# sobelow_skip["XSS.Raw"]
#  sobelow_skip ["XSS.Raw"]
# sobelow_skip [ "XSS.Raw" ]
# sobelow_skip ["XSS.Raw" , "Traversal"]
```

Ignored *in silence*, and indistinguishable from a skip that applied and found nothing to suppress. This is the same symptom #27 was filed for, which is what makes it worth fixing alongside: someone who lands on that issue, tries the syntax, and mistypes a space gets the identical non-result and no way to tell the two apart.

Spacing around the marker, inside the list, and around commas carries no meaning, so it is now irrelevant. The four variants that already worked (`#sobelow_skip`, `["A","B"]`, `["A", "B"]`, and a trailing comma) are covered by tests too, so the looser pattern can't quietly drop one.

## 2. Unreadable comments now say so

Whitespace was only the half I could anticipate. Anything that reads as an *attempt* at a skip comment — the marker followed by a bracket — and still survives the rewrite is now reported on stderr:

```
lib/my_app_web/router.ex:4: could not read this `# sobelow_skip` comment, so it was
ignored. Expected a list of double-quoted checks, for example: # sobelow_skip ["Config.CSRF"]
```

That covers single quotes and a list broken across several comment lines, both of which remain unaccepted — deliberately, since a charlist would reach `Sobelow.get_mod/1` as a list of integers — but they now tell you instead of leaving you to wonder.

Requiring the bracket is what keeps prose out of it. Sobelow's own source has several comments that mention `# sobelow_skip` in passing, and scanning itself stays quiet.

**On placement:** the warning is emitted from `Sobelow.get_file_meta/1`, the one pass that reads every file exactly once. `Parse.read_file/1` runs **six times** for a router — measured, not assumed — which is exactly where pipeline skips live, so warning from there would have repeated itself six times over. There's a test pinning that it fires once.

## 3. Scoping tests

The coverage #35 shipped with uses a single-pipeline router, leaving two things a real router depends on unpinned:

- **the skip lands only on the pipeline it annotates.** A real router has `:browser` and `:api` at minimum.
- **a blank line between the comment and `pipeline` still associates.** True because comments and blank lines are absent from the AST, but that's a property of how the parser sees the file, not obvious from the association code.

## Verification

Every guard checked in both directions:

| mutation | tests that fail |
|---|---|
| restore the old strict regex | 5 of the 8 spacing tests (the other 3 document behaviour that already worked) |
| call `Parse.ast/1` instead of `ast_with_skip_warnings/1` | all 3 warning tests |
| carry `pending` past a pipeline in `associate_skips_with_pipelines/1` | the cross-pipeline scoping test |

211 → 228. `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --all --strict` (no issues), `mix test` all green.
