### PR TITLE
feat: add GitHub Actions finding formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,9 @@ relative to the application root.
   * `--threshold` - Return findings at or above a confidence level
   of `low` (default), `medium`, or `high`.
 
-  * `--format` or `-f` - Specify findings output format. Accepts a format,
-  e.g. `txt` or `json`.
+  * `--format` or `-f` - Specify findings output format. Accepts `txt`, `json`,
+    `sarif`, or `github`. The `github` format emits workflow commands that
+    create inline annotations in GitHub Actions logs.
 
       Note that options such as `--verbose` will not work with the `json` format.
       All `json` formatted findings contain a `type`, `file`, and `line` key.

--- a/lib/mix/tasks/sobelow.ex
+++ b/lib/mix/tasks/sobelow.ex
@@ -29,7 +29,8 @@ defmodule Mix.Tasks.Sobelow do
   "cannot find the router" warning. Equivalent to `--router :none`
   * `--exit` - Return non-zero exit status
   * `--threshold` - Only return findings at or above a given confidence level
-  * `--format` - Specify findings output format
+  * `--format` - Specify findings output format (`txt`, `json`, `sarif`, or
+    `github` for GitHub Actions workflow commands)
   * `--quiet` - Return no output if there are no findings
   * `--compact` - Minimal, single-line findings
   * `--save-config` - Generates a configuration file based on command line options
@@ -343,7 +344,7 @@ defmodule Mix.Tasks.Sobelow do
   defp out_format("", format), do: format
 
   defp out_format(_out, format) do
-    if format in ["json", "quiet", "sarif"] do
+    if format in ["json", "quiet", "sarif", "github"] do
       format
     else
       "json"

--- a/lib/sobelow.ex
+++ b/lib/sobelow.ex
@@ -86,7 +86,7 @@ defmodule Sobelow do
     # - Remove config check from "allowed" modules
     # - Scan funcs from the root
     # - Scan funcs from the libroot
-    if format() not in ["quiet", "compact", "flycheck", "json"],
+    if format() not in ["quiet", "compact", "flycheck", "json", "github"],
       do: IO.puts(:stderr, print_banner())
 
     Application.put_env(:sobelow, :app_name, app_name)
@@ -157,6 +157,9 @@ defmodule Sobelow do
 
         "sarif" ->
           FindingLog.sarif(@v)
+
+        "github" ->
+          FindingLog.github()
 
         _ ->
           nil

--- a/lib/sobelow/finding_log.ex
+++ b/lib/sobelow/finding_log.ex
@@ -75,8 +75,49 @@ defmodule Sobelow.FindingLog do
     end
   end
 
+  @doc false
+  def github do
+    %{high: highs, medium: meds, low: lows} = log()
+
+    (highs ++ meds ++ lows)
+    |> sort_findings()
+    |> Enum.map_join("\n", &format_github/1)
+  end
+
   defp total(%{high: highs, medium: meds, low: lows}) do
     length(highs) + length(meds) + length(lows)
+  end
+
+  defp format_github({_details, finding, _custom_metadata}) do
+    level = if finding.confidence == :high, do: "error", else: "warning"
+
+    properties =
+      [
+        {"file", finding.filename},
+        {"line", finding.vuln_line_no},
+        {"col", finding.vuln_col_no},
+        {"title", finding.type}
+      ]
+      |> Enum.reject(fn {_key, value} -> is_nil(value) or value == 0 end)
+      |> Enum.map_join(",", fn {key, value} -> "#{key}=#{escape_command_value(value)}" end)
+
+    message =
+      case finding.vuln_variable do
+        nil -> finding.type
+        variable -> "#{finding.type}: #{variable}"
+      end
+
+    "::#{level} #{properties}::#{escape_command_value(message)}"
+  end
+
+  defp escape_command_value(value) do
+    value
+    |> to_string()
+    |> String.replace("%", "%25")
+    |> String.replace("\r", "%0D")
+    |> String.replace("\n", "%0A")
+    |> String.replace(":", "%3A")
+    |> String.replace(",", "%2C")
   end
 
   def init(:ok) do

--- a/test/e2e/scan_test.exs
+++ b/test/e2e/scan_test.exs
@@ -82,6 +82,14 @@ defmodule SobelowTest.E2E.ScanTest do
   end
 
   describe "output formats" do
+    test "github emits workflow commands with escaped properties" do
+      {stdout, _stderr} = scan_io("basic", format: "github")
+
+      assert stdout =~ ~r/^::(error|warning) file=.*line=\d+(,col=\d+)?,title=.*::/
+      assert stdout =~ "%3A"
+      refute stdout =~ "Running Sobelow"
+    end
+
     test "sarif emits one result per finding with a rule id" do
       {stdout, _stderr} = scan_io("basic", format: "sarif")
 

--- a/test/mix_task_test.exs
+++ b/test/mix_task_test.exs
@@ -145,6 +145,7 @@ defmodule SobelowTest.MixTaskTest do
 
     test "leaves machine-readable formats alone" do
       assert parse(["--out", "findings.sarif", "-f", "sarif"]).format == "sarif"
+      assert parse(["--out", "findings.log", "-f", "github"]).format == "github"
       assert parse(["--out", "findings.json", "-f", "json"]).format == "json"
       assert parse(["--out", "findings.txt", "--quiet"]).format == "quiet"
     end


### PR DESCRIPTION
## Summary

- add a `github` output format that emits escaped GitHub Actions workflow commands
- map high-confidence findings to error annotations and other findings to warnings
- preserve stable finding order and include file, line, column, and title metadata
- document the format and cover CLI selection plus end-to-end output

## Validation

- `git diff --check`

The Elixir toolchain (`mix`/`elixir`) is not installed in this environment, so I could not run the repository's formatter or ExUnit suite. The changed Elixir and test files were kept aligned with the existing style and the PR checks should provide the full validation.

The implementation was prepared with AI assistance and reviewed by me. I am responsible for the changes and this submission.

Closes #31