### PR TITLE
Fix for Workflow does not contain permissions issue

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 env:
   MIX_ENV: test
 


### PR DESCRIPTION
Potential fix for [https://github.com/sobelow/sobelow/security/code-scanning/1](https://github.com/sobelow/sobelow/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is restricted by default.  
Best fix here: define it at the workflow root (near `on:`), since all jobs in this file appear to need only read access and there is only one job. This preserves existing functionality while enforcing least privilege and documenting intent.

**File to edit:** `.github/workflows/elixir.yml`  
**Change:** Insert:

```yml
permissions:
  contents: read
```

between the trigger section and `env:` (or anywhere at top-level before `jobs:`).

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
