### PR TITLE
fix: Stop `.sobelow-conf` from being able to disable the scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,15 @@
     * Fixed a string-interpolation typo that rendered dot-access variables as
       `conn.${atom_to_string(field)}`.
     * `.sobelow-conf` keys are now genuinely sorted alphabetically.
+    * A `.sobelow-conf` can no longer stop Sobelow from scanning. `--save-config`
+      wrote `version` into every file it generated, so
+      `mix sobelow --version --save-config` produced a committed file that made
+      every later run print the version and **exit 0** — a CI gate reading that
+      as a clean scan. `version`, `details`, `all-details`, `save-config`, and
+      `diff` choose what Sobelow does rather than configure a scan, and are now
+      accepted on the command line only. One in the file is ignored, with a
+      warning when it would have changed anything. `version` is no longer
+      written to the file in the first place.
     * `# sobelow_skip` comments are no longer thrown away over whitespace. The
       pattern demanded exactly one space after the `#` and exactly one before
       the list, so `# sobelow_skip["XSS.Raw"]`, `#  sobelow_skip ["XSS.Raw"]`,

--- a/lib/mix/tasks/sobelow.ex
+++ b/lib/mix/tasks/sobelow.ex
@@ -117,6 +117,14 @@ defmodule Mix.Tasks.Sobelow do
 
   @aliases [v: :verbose, r: :root, i: :ignore, d: :details, f: :format]
 
+  # These pick what Sobelow *does* instead of configuring a scan, and every one
+  # of them ends the run before a scan happens. `.sobelow-conf` is read
+  # automatically and committed to the repository, so honouring one from the
+  # file means a checked-in file can stop the scanner from ever scanning —
+  # `version: true` prints the version and exits 0, which a CI gate reads as a
+  # clean scan. They are accepted on the command line only.
+  @cli_only_actions [:version, :details, :all_details, :save_config, :diff]
+
   # For escript entry
   def main(argv) do
     run(argv)
@@ -140,7 +148,7 @@ defmodule Mix.Tasks.Sobelow do
     opts =
       if conf_file? do
         # CLI args take precedence
-        Keyword.merge(load_config_file(conf_file), opts)
+        Keyword.merge(config_settings(conf_file), opts)
       else
         opts
       end
@@ -240,6 +248,37 @@ defmodule Mix.Tasks.Sobelow do
 
   defp validate_config(opts) do
     if Keyword.keyword?(opts), do: {:ok, opts}, else: :error
+  end
+
+  @doc false
+  # The settings from `.sobelow-conf`, with any command-line action dropped.
+  #
+  # A value that would not have changed anything is dropped in silence: every
+  # release up to v0.14.1 wrote `version: false` into the file that
+  # `--save-config` generated, so warning about it would fire for a great many
+  # existing projects that have nothing wrong with them.
+  def config_settings(conf_file) do
+    conf_file
+    |> load_config_file()
+    |> Enum.reject(fn {key, value} ->
+      if key in @cli_only_actions do
+        if value, do: warn_ignored_action(conf_file, key)
+        true
+      else
+        false
+      end
+    end)
+  end
+
+  defp warn_ignored_action(conf_file, key) do
+    Sobelow.IO.warn("""
+    Ignoring `#{key}` in #{conf_file}.
+
+    `--#{String.replace(to_string(key), "_", "-")}` chooses what Sobelow does \
+    rather than configuring a scan, and a configuration file that sets one \
+    stops the scan from running at all. Remove it from the file and pass it on \
+    the command line when you want it.
+    """)
   end
 
   defp load_config_file(conf_file) do

--- a/lib/sobelow.ex
+++ b/lib/sobelow.ex
@@ -273,8 +273,7 @@ defmodule Sobelow do
       router: get_env(:router),
       skip: get_env(:skip),
       threshold: get_env(:threshold),
-      verbose: get_env(:verbose),
-      version: get_env(:version)
+      verbose: get_env(:verbose)
     ]
 
     yes? =

--- a/lib/sobelow/io.ex
+++ b/lib/sobelow/io.ex
@@ -7,6 +7,10 @@ defmodule Sobelow.IO do
     IO.puts(:stderr, IO.ANSI.format([:red, :bright, message]))
   end
 
+  def warn(message) do
+    IO.puts(:stderr, IO.ANSI.format([:yellow, message]))
+  end
+
   def yes?(message) do
     answer = IO.gets(message <> " [Yn] ")
     is_binary(answer) and String.trim(answer) in ["", "y", "Y", "yes", "YES", "Yes"]

--- a/test/mix_task_test.exs
+++ b/test/mix_task_test.exs
@@ -195,6 +195,112 @@ defmodule SobelowTest.MixTaskTest do
     end
   end
 
+  # `.sobelow-conf` is read automatically and lives in version control, so a key
+  # that ends the run before a scan happens turns a committed file into a
+  # silently disabled scanner. `version: true` was the one that got there by
+  # accident: `--save-config` wrote it into every file it generated, and
+  # `mix sobelow --version --save-config` therefore produced a file that made
+  # every later run print the version and exit 0.
+  describe "command-line actions in .sobelow-conf" do
+    @describetag :tmp_dir
+
+    defp conf(tmp_dir, contents) do
+      path = Path.join(tmp_dir, ".sobelow-conf")
+      File.write!(path, contents)
+      path
+    end
+
+    for key <- [:version, :all_details, :save_config] do
+      test "#{key} is dropped", %{tmp_dir: tmp_dir} do
+        path = conf(tmp_dir, "[#{unquote(key)}: true, verbose: true]")
+
+        capture_io(:stderr, fn ->
+          assert Mix.Tasks.Sobelow.config_settings(path) == [verbose: true]
+        end)
+      end
+    end
+
+    test "details is dropped even though its value is a string", %{tmp_dir: tmp_dir} do
+      path = conf(tmp_dir, ~s([details: "Config.CSRF", verbose: true]))
+
+      capture_io(:stderr, fn ->
+        assert Mix.Tasks.Sobelow.config_settings(path) == [verbose: true]
+      end)
+    end
+
+    test "warn naming the file and the flag to use instead", %{tmp_dir: tmp_dir} do
+      path = conf(tmp_dir, ~s([version: true]))
+
+      stderr = capture_io(:stderr, fn -> Mix.Tasks.Sobelow.config_settings(path) end)
+
+      assert stderr =~ "Ignoring `version` in #{path}"
+      assert stderr =~ "--version"
+    end
+
+    test "warn about save_config using its command-line spelling", %{tmp_dir: tmp_dir} do
+      path = conf(tmp_dir, ~s([save_config: true]))
+
+      stderr = capture_io(:stderr, fn -> Mix.Tasks.Sobelow.config_settings(path) end)
+
+      assert stderr =~ "--save-config"
+      refute stderr =~ "--save_config"
+    end
+
+    # Every release up to v0.14.1 wrote `version: false` into the file that
+    # `--save-config` generated. Warning about a value that would not have done
+    # anything would fire for a great many projects with nothing wrong.
+    test "are dropped in silence when the value would not have done anything", %{tmp_dir: tmp_dir} do
+      path = conf(tmp_dir, ~s([verbose: true, version: false]))
+
+      stderr =
+        capture_io(:stderr, fn ->
+          assert Mix.Tasks.Sobelow.config_settings(path) == [verbose: true]
+        end)
+
+      assert stderr == ""
+    end
+
+    # The cases above call `config_settings/1` directly, which leaves the wiring
+    # untested. `--all-details` terminates the task's `cond` before the `version`
+    # branch, so the env is observable without running a scan: had the file been
+    # honoured, `:version` would be `true` here and every run in the project
+    # would print the version and exit 0.
+    test "are not reachable through the task itself", %{tmp_dir: tmp_dir} do
+      conf(tmp_dir, ~s([version: true]))
+
+      capture_io(:stderr, fn ->
+        capture_io(fn ->
+          Mix.Tasks.Sobelow.run(["--root", tmp_dir, "--private", "--all-details"])
+        end)
+      end)
+
+      assert Application.get_env(:sobelow, :version) == false
+    end
+
+    test "leave genuine settings untouched", %{tmp_dir: tmp_dir} do
+      path =
+        conf(tmp_dir, ~s([exit: :medium, format: "json", ignore: ["XSS.Raw"], verbose: true]))
+
+      assert Mix.Tasks.Sobelow.config_settings(path) ==
+               [exit: :medium, format: "json", ignore: ["XSS.Raw"], verbose: true]
+    end
+  end
+
+  describe "--save-config" do
+    @describetag :tmp_dir
+
+    test "does not persist a command-line action into the file", %{tmp_dir: tmp_dir} do
+      capture_io(fn ->
+        Mix.Tasks.Sobelow.run(["--root", tmp_dir, "--private", "--version", "--save-config"])
+      end)
+
+      {:ok, conf} = Mix.Tasks.Sobelow.read_config_file(Path.join(tmp_dir, ".sobelow-conf"))
+
+      refute Keyword.has_key?(conf, :version)
+      assert Keyword.has_key?(conf, :verbose)
+    end
+  end
+
   describe "read_config_file/1" do
     @describetag :tmp_dir
 

--- a/usage-rules.md
+++ b/usage-rules.md
@@ -119,6 +119,11 @@ Precedence rules:
 - **CLI switches override the file.**
 - `--no-config` ignores the file for that run.
 
+The file holds settings only. `--version`, `--details`, `--all-details`,
+`--save-config`, and `--diff` pick what Sobelow does instead of configuring a
+scan, and each ends the run before one happens, so they are ignored if they
+appear in the file.
+
 Commit `.sobelow-conf`. Paths in it are stored relative to the project root, so it
 works on other machines and in CI.
 


### PR DESCRIPTION
Closes #15.

### What the reporter saw

> When using `.sobelow-conf` and I set `verbose: true` Sobelow would only print the version.

`verbose: true` on its own is fine — I checked, on `main` and on v0.14.0, which was the current release when this was filed. The key that produces this symptom is the one a character away: `version: true`.

That is not a far-fetched typo to land on, because **`--save-config` wrote `version` into every file it generated**:

```console
$ mix sobelow --version --save-config
Updated .sobelow-conf

$ cat .sobelow-conf
[..., threshold: :low, verbose: false, version: true]
```

`--save-config` comes before `version` in the task's `cond`, so that combination saves a file and *then* the file makes every later run print the version and stop.

### Why it got worse

v0.14.1 made `.sobelow-conf` read automatically. So on `main`, before this PR:

```console
$ mix sobelow                       # committed conf has version: true
0.14.1

$ mix sobelow --verbose             # no flag can rescue it
0.14.1

$ mix sobelow --exit low ; echo $?  # real findings present
0
```

There is no `--no-version` to override it with, because `version` is only ever read as truthy. And the run **exits 0** — so `mix sobelow --exit low` in CI passes having scanned nothing. Same failure shape as the version-check-cache bug fixed earlier this cycle: the gate goes green on an empty scan.

### The rule

`version`, `details`, `all_details`, `save_config`, and `diff` pick what Sobelow *does* rather than configure a scan, and every one of them ends the run before a scan happens. A file that is committed and read automatically has no business carrying one. Two of the others are just as bad in their own way:

| key in the file | what happens today |
|---|---|
| `details: "Config.CSRF"` | prints the check's documentation, never scans |
| `save_config: true` | rewrites the file and blocks on `Are you sure you want to overwrite? [Yn]` — in CI that never returns |

All five are now command-line only. A file that sets one has it dropped, with a warning:

```
Ignoring `version` in ./.sobelow-conf.

`--version` chooses what Sobelow does rather than configuring a scan, and a
configuration file that sets one stops the scan from running at all. Remove it
from the file and pass it on the command line when you want it.
```

`version` is also no longer written to the file, so this stops being generated in the first place.

**The warning fires only when the value would have changed something.** Every release up to v0.14.1 wrote `version: false` into the file `--save-config` generated, so warning on the mere presence of the key would fire for a great many existing projects that have nothing wrong with them.

### On the reporter's two suggestions

- *"print the version in the first line and below it the output of running Sobelow"* — I went the other way. Reading an action out of a config file is the bug; making it do both would keep a committed file able to change what the command means.
- *"not to include `verbose` as an option in the config"* — `verbose` is a genuine setting and stays. It was the wrong suspect.

### Verification

Each guard checked by mutation:

| mutation | tests that fail |
|---|---|
| `Keyword.merge(load_config_file(...), opts)` at the call site | the wiring test — the direct `config_settings/1` tests still pass, which is exactly why that test exists |
| restore `version: get_env(:version)` in `save_config/1` | the `--save-config` persistence test |

The wiring test uses `--all-details` to terminate the task's `cond` before the `version` branch, so the resulting env is observable without running a scan.

228 → 238. `mix format --check-formatted`, `mix compile --warnings-as-errors`, `mix credo --all --strict` (no issues), `mix test` all green.
