### PR TITLE
Add Github Workflow annotations output format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+  * Enhancements
+    * Added a `github` output format that emits GitHub Actions workflow
+      annotations for findings.
+
 ## v0.15.0
   * Bug fixes
     * `Config.Secrets` no longer crashes the scan when a secret is written as

--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ relative to the application root.
   * `--threshold` - Return findings at or above a confidence level
   of `low` (default), `medium`, or `high`.
 
-  * `--format` or `-f` - Specify findings output format. Accepts a format,
-  e.g. `txt` or `json`.
+  * `--format` or `-f` - Specify findings output format. Accepts `txt`, `json`,
+  `sarif`, or `github`.
 
       Note that options such as `--verbose` will not work with the `json` format.
       All `json` formatted findings contain a `type`, `file`, and `line` key.

--- a/lib/mix/tasks/sobelow.ex
+++ b/lib/mix/tasks/sobelow.ex
@@ -29,7 +29,7 @@ defmodule Mix.Tasks.Sobelow do
   "cannot find the router" warning. Equivalent to `--router :none`
   * `--exit` - Return non-zero exit status
   * `--threshold` - Only return findings at or above a given confidence level
-  * `--format` - Specify findings output format
+  * `--format` - Specify findings output format (`txt`, `json`, `sarif`, or `github`)
   * `--quiet` - Return no output if there are no findings
   * `--compact` - Minimal, single-line findings
   * `--save-config` - Generates a configuration file based on command line options
@@ -382,7 +382,7 @@ defmodule Mix.Tasks.Sobelow do
   defp out_format("", format), do: format
 
   defp out_format(_out, format) do
-    if format in ["json", "quiet", "sarif"] do
+    if format in ["json", "quiet", "sarif", "github"] do
       format
     else
       "json"

--- a/lib/sobelow.ex
+++ b/lib/sobelow.ex
@@ -86,7 +86,7 @@ defmodule Sobelow do
     # - Remove config check from "allowed" modules
     # - Scan funcs from the root
     # - Scan funcs from the libroot
-    if format() not in ["quiet", "compact", "flycheck", "json"],
+    if format() not in ["quiet", "compact", "flycheck", "json", "github"],
       do: IO.puts(:stderr, print_banner())
 
     Application.put_env(:sobelow, :app_name, app_name)
@@ -157,6 +157,9 @@ defmodule Sobelow do
 
         "sarif" ->
           FindingLog.sarif(@v)
+
+        "github" ->
+          FindingLog.github()
 
         _ ->
           nil

--- a/lib/sobelow/finding_log.ex
+++ b/lib/sobelow/finding_log.ex
@@ -75,8 +75,68 @@ defmodule Sobelow.FindingLog do
     end
   end
 
+  def github do
+    %{high: highs, medium: meds, low: lows} = log()
+
+    (highs ++ meds ++ lows)
+    |> sort_findings()
+    |> Enum.map_join("\n", &format_github/1)
+    |> case do
+      "" -> nil
+      text -> text
+    end
+  end
+
   defp total(%{high: highs, medium: meds, low: lows}) do
     length(highs) + length(meds) + length(lows)
+  end
+
+  defp format_github({_details, finding, _custom_metadata}) do
+    properties = github_properties(finding)
+
+    message =
+      "Sobelow: #{finding.type} (#{finding.confidence} confidence)"
+      |> escape_data()
+
+    "::warning #{properties}::#{message}"
+  end
+
+  defp github_properties(finding) do
+    line = positive_integer(finding.vuln_line_no)
+    column = positive_integer(finding.vuln_col_no)
+
+    properties =
+      [
+        {"file", relative_filename(finding.filename)},
+        {"line", line},
+        {"endLine", line},
+        {"col", column}
+      ]
+
+    properties
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+    |> Enum.map_join(",", fn {key, value} -> "#{key}=#{escape_property(value)}" end)
+  end
+
+  defp relative_filename(nil), do: nil
+  defp relative_filename(filename), do: Path.relative_to_cwd(filename)
+
+  defp positive_integer(value) when is_integer(value) and value > 0, do: value
+  defp positive_integer(_value), do: 1
+
+  defp escape_data(value) do
+    value
+    |> to_string()
+    |> String.replace("%", "%25")
+    |> String.replace("\r", "%0D")
+    |> String.replace("\n", "%0A")
+  end
+
+  defp escape_property(value) do
+    value
+    |> escape_data()
+    |> String.replace(":", "%3A")
+    |> String.replace(",", "%2C")
   end
 
   def init(:ok) do

--- a/test/e2e/scan_test.exs
+++ b/test/e2e/scan_test.exs
@@ -82,6 +82,40 @@ defmodule SobelowTest.E2E.ScanTest do
   end
 
   describe "output formats" do
+    test "github emits workflow annotations with confidence in the message" do
+      temp_fixture_file(
+        "basic",
+        "lib/basic_web/controllers/annotated,finding_controller.ex",
+        """
+        defmodule BasicWeb.AnnotatedFindingController do
+          def show(conn, %{"path" => path}), do: send_file(conn, 200, path)
+        end
+        """
+      )
+
+      {stdout, _stderr} = scan_io("basic", format: "github")
+
+      assert stdout =~
+               ~r/^::warning file=.*page_controller\.ex,line=5,endLine=5,col=\d+::Sobelow: Traversal\.SendFile: Directory Traversal in `send_file` \(high confidence\)$/m
+    end
+
+    test "github emits annotations for findings without a line number" do
+      {stdout, _stderr} = scan_io("basic", format: "github")
+
+      assert stdout =~
+               "::warning file=test/fixtures/apps/basic/config/prod.secret.exs," <>
+                 "line=1,endLine=1,col=1::" <>
+                 "Sobelow: Config.HSTS: HSTS Not Enabled (medium confidence)"
+    end
+
+    test "github emits nothing when there are no findings" do
+      all_categories = ~w(XSS SQL Traversal RCE Misc Config CI DOS Vuln)
+
+      {stdout, _stderr} = scan_io("basic", format: "github", ignored: all_categories)
+
+      assert stdout == ""
+    end
+
     test "sarif emits one result per finding with a rule id" do
       {stdout, _stderr} = scan_io("basic", format: "sarif")
 

--- a/test/mix_task_test.exs
+++ b/test/mix_task_test.exs
@@ -145,6 +145,7 @@ defmodule SobelowTest.MixTaskTest do
 
     test "leaves machine-readable formats alone" do
       assert parse(["--out", "findings.sarif", "-f", "sarif"]).format == "sarif"
+      assert parse(["--out", "findings.log", "-f", "github"]).format == "github"
       assert parse(["--out", "findings.json", "-f", "json"]).format == "json"
       assert parse(["--out", "findings.txt", "--quiet"]).format == "quiet"
     end


### PR DESCRIPTION
As discussed in #31, this adds new `--format github` option that prints the results compatible with [Github workflow annotations](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands), which then appear inline in the PR.

<img width="994" height="578" alt="Screenshot 2026-08-18 at 14 24 04" src="https://github.com/user-attachments/assets/2e7fd4b8-9931-41bf-9c47-122ffa9b78a4" />

All warning, no matter the confidence score, are reported as warning. If the warning is not attached to a particular line/column, it reports on `1,1` of the file. You can see these in action here: https://github.com/katafrakt/sobelow_annotation_demo/pull/1/changes

## Note

I also experimented with using `title` param from annotations API, but wasn't satisfied how the results look like. However, I'm open to discuss that and more experimentation.

<img width="972" height="609" alt="Screenshot 2026-08-18 at 13 51 04" src="https://github.com/user-attachments/assets/af6ddbfc-90d7-42ca-99ab-2df492fb79a7" />
(here IMO "Sobelow" stands out too much and is duplicated in the message - we could remove the prefix from the message too or put something else in the title, like a finding name or "Sobelow (low confidence)", but I think it's good as is).
